### PR TITLE
Bump lifecycle chart version to 0.2.0

### DIFF
--- a/charts/lifecycle/Chart.yaml
+++ b/charts/lifecycle/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: lifecycle
 description: A Helm umbrella chart for full Lifecycle stack
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: 0.0.6-alpha.3
 
 dependencies:

--- a/charts/lifecycle/README.md
+++ b/charts/lifecycle/README.md
@@ -1,6 +1,6 @@
 # lifecycle
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.6-alpha.3](https://img.shields.io/badge/AppVersion-0.0.6--alpha.3-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.6-alpha.3](https://img.shields.io/badge/AppVersion-0.0.6--alpha.3-informational?style=flat-square)
 
 A Helm umbrella chart for full Lifecycle stack
 


### PR DESCRIPTION
Updated the Helm chart version in Chart.yaml from 0.1.0 to 0.2.0 to reflect new changes or improvements in the lifecycle stack.