### PR TITLE
fix(kri): use global hostname for Keycloak OIDC endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ A collection of Helm charts primarily used for **Lifecycle** application deploym
 | :--- | :--- | :--- | :--- |
 | [keycloak-operator](./charts/keycloak-operator) | `0.1.0` | `26.4.7` | Helm chart for Keycloak operator based on the [official manifests](https://www.keycloak.org/operator/installation#_installing_by_using_kubectl_without_operator_lifecycle_manager) |
 | [lifecycle](./charts/lifecycle) | `0.3.3` | `0.1.3` | A Helm umbrella chart for full Lifecycle stack |
-| [lifecycle-keycloak](./charts/lifecycle-keycloak) | `0.1.1` | `0.0.0` | Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports |
+| [lifecycle-keycloak](./charts/lifecycle-keycloak) | `0.1.2` | `0.0.0` | Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports |
 | [lifecycle-ui](./charts/lifecycle-ui) | `0.1.1` | `0.1.1` | A Helm chart for Lifecycle UI (Next.js) |

--- a/charts/lifecycle-keycloak/Chart.yaml
+++ b/charts/lifecycle-keycloak/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: lifecycle-keycloak
 description: Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 0.0.0
 home: https://goodrxoss.github.io/helm-charts/charts/lifecycle-keycloak/
 

--- a/charts/lifecycle-keycloak/README.md
+++ b/charts/lifecycle-keycloak/README.md
@@ -1,6 +1,6 @@
 # lifecycle-keycloak
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports
 
@@ -128,7 +128,7 @@ This chart uses the `KeycloakRealmImport` resource for the initial setup.
 ```shell
 helm upgrade -i lifecycle-keycloak \
   oci://ghcr.io/goodrxoss/helm-charts/lifecycle-keycloak \
-  --version 0.1.1 \
+  --version 0.1.2 \
   -f values.yaml \
   -n lifecycle-keycloak \
   --create-namespace

--- a/charts/lifecycle-keycloak/templates/lifecycle-realm-kri.yaml
+++ b/charts/lifecycle-keycloak/templates/lifecycle-realm-kri.yaml
@@ -145,8 +145,8 @@ spec:
           clientId: {{ .Values.internalIdp.clientId | quote }}
           clientAuthMethod: "private_key_jwt"
           clientAssertionSigningAlg: "RS256"
-          tokenUrl: {{ printf "http://%s-service.%s:8080/realms/%s/protocol/openid-connect/token" (include "lifecycle-keycloak.fullname" .) (include "lifecycle-keycloak.namespaceHostname" .) .Values.internalIdp.realm | quote }}
-          jwksUrl: {{ printf "http://%s-service.%s:8080/realms/%s/protocol/openid-connect/certs" (include "lifecycle-keycloak.fullname" .) (include "lifecycle-keycloak.namespaceHostname" .) .Values.internalIdp.realm | quote }}
+          tokenUrl: {{ printf "%s/realms/%s/protocol/openid-connect/token" .Values.hostname .Values.internalIdp.realm | quote }}
+          jwksUrl: {{ printf "%s/realms/%s/protocol/openid-connect/certs" .Values.hostname .Values.internalIdp.realm | quote }}
           authorizationUrl: {{ printf "%s/realms/%s/protocol/openid-connect/auth" .Values.hostname .Values.internalIdp.realm | quote }}
           logoutUrl: {{ printf "%s/realms/%s/protocol/openid-connect/logout" .Values.hostname .Values.internalIdp.realm | quote }}
           clientAssertionAudience: {{ printf "%s/realms/%s" .Values.hostname .Values.internalIdp.realm | quote }}


### PR DESCRIPTION
**Description:**
This PR updates the Keycloak configuration to use the public-facing hostname instead of internal Kubernetes service addresses.

**Changes:**

* Updated `tokenUrl` to use `{{ .Values.hostname }}`.
* Updated `jwksUrl` to use `{{ .Values.hostname }}`.

**Why this is necessary:**
Using internal cluster addresses for OIDC endpoints often causes `Issuer mismatch` errors during token validation, as the client (browser or external service) expects the URLs to match the public identity provider address
