### PR TITLE
chore(secrets): move Github App default values to Application logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ A collection of Helm charts primarily used for **Lifecycle** application deploym
 | Chart | Version | App Version | Description |
 | :--- | :--- | :--- | :--- |
 | [keycloak-operator](./charts/keycloak-operator) | `0.1.0` | `26.4.7` | Helm chart for Keycloak operator based on the [official manifests](https://www.keycloak.org/operator/installation#_installing_by_using_kubectl_without_operator_lifecycle_manager) |
-| [lifecycle](./charts/lifecycle) | `0.3.3` | `0.1.3` | A Helm umbrella chart for full Lifecycle stack |
+| [lifecycle](./charts/lifecycle) | `0.4.0` | `0.1.11` | A Helm umbrella chart for full Lifecycle stack |
 | [lifecycle-keycloak](./charts/lifecycle-keycloak) | `0.2.0` | `0.0.0` | Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports |
 | [lifecycle-ui](./charts/lifecycle-ui) | `0.1.1` | `0.1.1` | A Helm chart for Lifecycle UI (Next.js) |

--- a/charts/lifecycle/Chart.yaml
+++ b/charts/lifecycle/Chart.yaml
@@ -16,8 +16,8 @@ apiVersion: v2
 name: lifecycle
 description: A Helm umbrella chart for full Lifecycle stack
 type: application
-version: 0.3.3
-appVersion: 0.1.3
+version: 0.4.0
+appVersion: 0.1.11
 
 dependencies:
   # PostgreSQL Dependency

--- a/charts/lifecycle/README.md
+++ b/charts/lifecycle/README.md
@@ -1,6 +1,6 @@
 # lifecycle
 
-![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.1.3](https://img.shields.io/badge/AppVersion-0.1.3-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.1.11](https://img.shields.io/badge/AppVersion-0.1.11-informational?style=flat-square)
 
 A Helm umbrella chart for full Lifecycle stack
 
@@ -40,7 +40,7 @@ buildkit:
 ```bash
 helm upgrade -i lifecycle \
   oci://ghcr.io/goodrxoss/helm-charts/lifecycle \
-  --version 0.3.3 \
+  --version 0.4.0 \
   -f values.yaml \
   -n lifecycle-app \
   --create-namespace

--- a/charts/lifecycle/templates/secret-bootstrap.yaml
+++ b/charts/lifecycle/templates/secret-bootstrap.yaml
@@ -44,13 +44,24 @@ metadata:
 type: Opaque
 data:
   {{- with . }}
-  # Github App Secrets
-  GITHUB_PRIVATE_KEY: {{ .githubPrivateKey | default "YOUR_VALUE_HERE" | b64enc | quote }}
-  GITHUB_CLIENT_SECRET: {{ .githubClientSecret | default "YOUR_VALUE_HERE" | b64enc | quote }}
-  GITHUB_WEBHOOK_SECRET: {{ .githubWebhookSecret | default "YOUR_VALUE_HERE" | b64enc | quote }}
-  GITHUB_APP_ID: {{ .githubAppId | default "YOUR_VALUE_HERE" | b64enc | quote }}
-  GITHUB_CLIENT_ID: {{ .githubClientId | default "YOUR_VALUE_HERE" | b64enc | quote }}
-  GITHUB_APP_INSTALLATION_ID: {{ .githubInstallationId | default "YOUR_VALUE_HERE" | b64enc | quote }}
+  {{- if .githubPrivateKey }}
+  GITHUB_PRIVATE_KEY: {{ .githubPrivateKey | b64enc | quote }}
+  {{- end }}
+  {{- if .githubClientSecret }}
+  GITHUB_CLIENT_SECRET: {{ .githubClientSecret | b64enc | quote }}
+  {{- end }}
+  {{- if .githubWebhookSecret }}
+  GITHUB_WEBHOOK_SECRET: {{ .githubWebhookSecret | b64enc | quote }}
+  {{- end }}
+  {{- if .githubAppId }}
+  GITHUB_APP_ID: {{ .githubAppId | b64enc | quote }}
+  {{- end }}
+  {{- if .githubClientId }}
+  GITHUB_CLIENT_ID: {{ .githubClientId | b64enc | quote }}
+  {{- end }}
+  {{- if .githubInstallationId }}
+  GITHUB_APP_INSTALLATION_ID: {{ .githubInstallationId | b64enc | quote }}
+  {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
### Description

This PR updates the Helm chart to remove hardcoded default values (`YOUR_VALUE_HERE`) for GitHub App secrets. Instead of always rendering these keys in the bootstrap process, the chart now only includes them if they are explicitly provided in the values.

The responsibility for handling default values and missing configurations has been moved directly into the **Application logic** (see https://github.com/GoodRxOSS/lifecycle/pull/93).

### Key Changes

* **Conditional Rendering:** GitHub secret keys are now wrapped in `if` blocks. They will no longer be generated with placeholder strings.
* **Version Bump:** Incremented the **minor version** of the Helm chart due to breaking changes in how secrets are handled.

### ⚠️ Breaking Changes & Compatibility

* **App Version Requirement:** This version of the Helm chart is **only compatible** with Application version `0.1.11` or higher.
* **Dependency:** This change relies on the application logic updates implemented in https://github.com/GoodRxOSS/lifecycle/pull/93.
* **Action Required:** If you were relying on the chart to provide placeholder strings for these secrets, ensure your application is updated to the required version to handle missing keys gracefully.