### PR TITLE
fix(kri): use external hostname for JWKS endpoint instead of internal service URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ A collection of Helm charts primarily used for **Lifecycle** application deploym
 | :--- | :--- | :--- | :--- |
 | [keycloak-operator](./charts/keycloak-operator) | `0.1.0` | `26.4.7` | Helm chart for Keycloak operator based on the [official manifests](https://www.keycloak.org/operator/installation#_installing_by_using_kubectl_without_operator_lifecycle_manager) |
 | [lifecycle](./charts/lifecycle) | `0.4.0` | `0.1.11` | A Helm umbrella chart for full Lifecycle stack |
-| [lifecycle-keycloak](./charts/lifecycle-keycloak) | `0.2.0` | `0.0.0` | Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports |
+| [lifecycle-keycloak](./charts/lifecycle-keycloak) | `0.3.0` | `0.0.0` | Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports |
 | [lifecycle-ui](./charts/lifecycle-ui) | `0.1.1` | `0.1.1` | A Helm chart for Lifecycle UI (Next.js) |

--- a/charts/lifecycle-keycloak/Chart.yaml
+++ b/charts/lifecycle-keycloak/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: lifecycle-keycloak
 description: Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: 0.0.0
 home: https://goodrxoss.github.io/helm-charts/charts/lifecycle-keycloak/
 

--- a/charts/lifecycle-keycloak/README.md
+++ b/charts/lifecycle-keycloak/README.md
@@ -1,6 +1,6 @@
 # lifecycle-keycloak
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports
 
@@ -128,7 +128,7 @@ This chart uses the `KeycloakRealmImport` resource for the initial setup.
 ```shell
 helm upgrade -i lifecycle-keycloak \
   oci://ghcr.io/goodrxoss/helm-charts/lifecycle-keycloak \
-  --version 0.2.0 \
+  --version 0.3.0 \
   -f values.yaml \
   -n lifecycle-keycloak \
   --create-namespace

--- a/charts/lifecycle-keycloak/templates/internal-realm-kri.yaml
+++ b/charts/lifecycle-keycloak/templates/internal-realm-kri.yaml
@@ -65,7 +65,7 @@ spec:
         clientAuthenticatorType: "client-jwt"
         attributes:
           use.jwks.url: "true"
-          jwks.url: {{ printf "http://%s-service.%s:8080/realms/%s/protocol/openid-connect/certs" (include "lifecycle-keycloak.fullname" .) (include "lifecycle-keycloak.namespaceHostname" .) .Values.realm | quote }}
+          jwks.url: {{ printf "%s/realms/%s/protocol/openid-connect/certs" .Values.hostname .Values.realm | quote }}
           token.endpoint.auth.signing.alg: "RS256"
         publicClient: false
         redirectUris:


### PR DESCRIPTION
### **Description**

This PR updates the `jwks.url` configuration to use the external `.Values.hostname` instead of the internal Kubernetes service discovery address.

### **Changes**

* **Modified:** `jwks.url` template logic.
* **From:** `http://{{ .Release.Name }}-service...:8080/...`
* **To:** `{{ .Values.hostname }}/...`

### **Reasoning**

* **Keycloak Compatibility:** This change is required to pass **import validation** in Keycloak. Keycloak often enforces strict matches between the token issuer claim and the JWKS endpoint. Using the external URL ensures consistency across the authentication flow.
* **Increased Stability:** The external URL (hostname) is more resilient to infrastructure changes. Internal service names or ports (like `:8080`) are subject to change during cluster refactoring or namespace migrations, whereas the public-facing endpoint remains a stable contract.
* **SSL/TLS Consistency:** Relying on the external hostname ensures that the application interacts with Keycloak via the same secure layer (HTTPS) used by end-users, avoiding "mixed content" or protocol mismatch issues.