### PR TITLE
chore(lifecycle-keycloak): remove redundant lifecycle-ui-backend client and service account

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ A collection of Helm charts primarily used for **Lifecycle** application deploym
 | :--- | :--- | :--- | :--- |
 | [keycloak-operator](./charts/keycloak-operator) | `0.1.0` | `26.4.7` | Helm chart for Keycloak operator based on the [official manifests](https://www.keycloak.org/operator/installation#_installing_by_using_kubectl_without_operator_lifecycle_manager) |
 | [lifecycle](./charts/lifecycle) | `0.4.0` | `0.1.11` | A Helm umbrella chart for full Lifecycle stack |
-| [lifecycle-keycloak](./charts/lifecycle-keycloak) | `0.3.0` | `0.0.0` | Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports |
+| [lifecycle-keycloak](./charts/lifecycle-keycloak) | `0.4.0` | `0.0.0` | Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports |
 | [lifecycle-ui](./charts/lifecycle-ui) | `0.2.0` | `0.1.2` | A Helm chart for Lifecycle UI (Next.js) |

--- a/charts/lifecycle-keycloak/Chart.yaml
+++ b/charts/lifecycle-keycloak/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: lifecycle-keycloak
 description: Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports
 type: application
-version: 0.3.0
+version: 0.4.0
 appVersion: 0.0.0
 home: https://goodrxoss.github.io/helm-charts/charts/lifecycle-keycloak/
 

--- a/charts/lifecycle-keycloak/README.md
+++ b/charts/lifecycle-keycloak/README.md
@@ -1,6 +1,6 @@
 # lifecycle-keycloak
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports
 
@@ -128,7 +128,7 @@ This chart uses the `KeycloakRealmImport` resource for the initial setup.
 ```shell
 helm upgrade -i lifecycle-keycloak \
   oci://ghcr.io/goodrxoss/helm-charts/lifecycle-keycloak \
-  --version 0.3.0 \
+  --version 0.4.0 \
   -f values.yaml \
   -n lifecycle-keycloak \
   --create-namespace
@@ -145,9 +145,6 @@ helm upgrade -i lifecycle-keycloak \
 | clients.lifecycleUi.clientSecret | string | `"lifecycle-ui-secret"` |  |
 | clients.lifecycleUi.enabled | bool | `true` |  |
 | clients.lifecycleUi.url | string | `"http://localhost:3000"` |  |
-| clients.lifecycleUiBackend.clientId | string | `"lifecycle-ui-backend"` |  |
-| clients.lifecycleUiBackend.clientSecret | string | `"lifecycle-ui-backend-secret"` |  |
-| clients.lifecycleUiBackend.enabled | bool | `true` |  |
 | companyIdp.authorizationUrl | string | `nil` |  |
 | companyIdp.clientId | string | `nil` |  |
 | companyIdp.clientSecret | string | `nil` |  |

--- a/charts/lifecycle-keycloak/templates/lifecycle-realm-kri.yaml
+++ b/charts/lifecycle-keycloak/templates/lifecycle-realm-kri.yaml
@@ -40,18 +40,6 @@ spec:
     adminTheme: "keycloak"
     emailTheme: "keycloak"
 
-    # --- USERS ---
-    users:
-      - username: "service-account-lifecycle-ui-backend"
-        enabled: true
-        serviceAccountClientId: "lifecycle-ui-backend"
-        realmRoles:
-          - "default-roles-lifecycle"
-        clientRoles:
-          realm-management:
-            - "view-users"
-            - "query-users"
-
     # --- CLIENTS ---
     clients:
       - clientId: "broker"
@@ -81,8 +69,7 @@ spec:
         secret: {{ .Values.clients.lifecycleUi.clientSecret | quote }}
         redirectUris:
           - "{{ .Values.clients.lifecycleUi.url }}"
-          - "{{ .Values.clients.lifecycleUi.url }}/"
-          - "{{ .Values.clients.lifecycleUi.url }}/api/auth/callback/keycloak"
+          - "{{ .Values.clients.lifecycleUi.url }}/*"
         webOrigins: ["+"]
         standardFlowEnabled: true
         protocol: "openid-connect"
@@ -120,22 +107,6 @@ spec:
               userinfo.token.claim: "true"
               jsonType.label: "String"
               introspection.token.claim: "true"
-
-      - clientId: {{ .Values.clients.lifecycleUiBackend.clientId | quote }}
-        enabled: {{ .Values.clients.lifecycleUiBackend.enabled }}
-        clientAuthenticatorType: "client-secret"
-        secret: {{ .Values.clients.lifecycleUiBackend.clientSecret | quote }}
-        redirectUris: ["/*"]
-        webOrigins: ["/*"]
-        standardFlowEnabled: true
-        serviceAccountsEnabled: true
-        frontchannelLogout: true
-        protocol: "openid-connect"
-        attributes:
-          frontchannel.logout.session.required: "true"
-          backchannel.logout.session.required: "true"
-        defaultClientScopes: ["web-origins", "service_account", "acr", "roles", "profile", "basic", "email"]
-        optionalClientScopes: ["address", "phone", "offline_access", "organization", "microprofile-jwt"]
 
     # --- IDENTITY PROVIDERS ---
     identityProviders:

--- a/charts/lifecycle-keycloak/values.yaml
+++ b/charts/lifecycle-keycloak/values.yaml
@@ -34,11 +34,6 @@ clients:
     clientSecret: lifecycle-ui-secret
     url: http://localhost:3000
 
-  lifecycleUiBackend:
-    enabled: true
-    clientId: lifecycle-ui-backend
-    clientSecret: lifecycle-ui-backend-secret
-
 companyIdp:
   enabled: true
   clientId:  # fallback to "${vault.company_idp_client_id}"


### PR DESCRIPTION
### Description

#### **Summary**

Following the simplification of the UI authentication logic, this PR cleans up the Keycloak realm configuration. It removes the dedicated backend service client and its associated service account, as they are no longer required for user verification.

#### **Key Changes**

* **Deleted `lifecycle-ui-backend` Client:** Removed the Keycloak client definition that was previously used for server-side authentication.
* **Removed Service Account:** Deleted the `service-account-lifecycle-ui-backend` user and its associated realm roles (`view-users`, `query-users`).
* **Refined Redirect URIs:** Updated the remaining `lifecycleUi` client to use a wildcard redirect URI (`/*`) for better flexibility and consistency.
* **Cleanup:** Removed obsolete Helm template references to `lifecycleUiBackend`.

#### **Impact**

* ✅ **Security:** Reduced the number of active clients and service accounts within the realm, adhering to the principle of least privilege.
* ✅ **Maintenance:** Simplified the Keycloak chart configuration by removing unused resources.
* ✅ **Optimization:** Cleaned up the realm manifest, making it easier to manage and audit.

#### **Reference**
* https://github.com/GoodRxOSS/lifecycle-ui/pull/18
* https://github.com/GoodRxOSS/helm-charts/pull/22