### PR TITLE
chore(lifecycle-keycloak): standardise naming helpers and fix subchart scoping

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ A collection of Helm charts primarily used for **Lifecycle** application deploym
 | :--- | :--- | :--- | :--- |
 | [keycloak-operator](./charts/keycloak-operator) | `0.1.0` | `26.4.7` | Helm chart for Keycloak operator based on the [official manifests](https://www.keycloak.org/operator/installation#_installing_by_using_kubectl_without_operator_lifecycle_manager) |
 | [lifecycle](./charts/lifecycle) | `0.4.0` | `0.1.11` | A Helm umbrella chart for full Lifecycle stack |
-| [lifecycle-keycloak](./charts/lifecycle-keycloak) | `0.4.0` | `0.0.0` | Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports |
+| [lifecycle-keycloak](./charts/lifecycle-keycloak) | `0.5.0` | `0.0.0` | Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports |
 | [lifecycle-ui](./charts/lifecycle-ui) | `0.2.0` | `0.1.2` | A Helm chart for Lifecycle UI (Next.js) |

--- a/charts/lifecycle-keycloak/Chart.yaml
+++ b/charts/lifecycle-keycloak/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: lifecycle-keycloak
 description: Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports
 type: application
-version: 0.4.0
+version: 0.5.0
 appVersion: 0.0.0
 home: https://goodrxoss.github.io/helm-charts/charts/lifecycle-keycloak/
 
@@ -26,7 +26,7 @@ annotations:
 
 dependencies:
   - name: postgresql
-    alias: postgres
+    alias: keycloakPostgres
     version: 15.5.19
     repository: "https://charts.bitnami.com/bitnami"
     condition: postgres.enabled

--- a/charts/lifecycle-keycloak/README.md
+++ b/charts/lifecycle-keycloak/README.md
@@ -1,6 +1,6 @@
 # lifecycle-keycloak
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports
 
@@ -18,7 +18,7 @@ This chart does **not** install the Keycloak Operator itself. It manages the con
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgres(postgresql) | 15.5.19 |
+| https://charts.bitnami.com/bitnami | keycloakPostgres(postgresql) | 15.5.19 |
 
 ---
 
@@ -128,7 +128,7 @@ This chart uses the `KeycloakRealmImport` resource for the initial setup.
 ```shell
 helm upgrade -i lifecycle-keycloak \
   oci://ghcr.io/goodrxoss/helm-charts/lifecycle-keycloak \
-  --version 0.4.0 \
+  --version 0.5.0 \
   -f values.yaml \
   -n lifecycle-keycloak \
   --create-namespace
@@ -177,21 +177,22 @@ helm upgrade -i lifecycle-keycloak \
 | internalIdp.users.bootstrapUser.lastName | string | `"Bootstrap"` |  |
 | internalIdp.users.bootstrapUser.password | string | `"lifecycle"` |  |
 | internalIdp.users.bootstrapUser.username | string | `"lifecycle"` |  |
+| keycloakPostgres.auth.database | string | `"keycloak"` |  |
+| keycloakPostgres.auth.existingSecret | string | `"{{ include \"lifecycle-keycloak.postgresSecretName\" . }}"` |  |
+| keycloakPostgres.auth.secretKeys.adminPasswordKey | string | `"POSTGRES_ADMIN_PASSWORD"` |  |
+| keycloakPostgres.auth.secretKeys.userPasswordKey | string | `"POSTGRES_USER_PASSWORD"` |  |
+| keycloakPostgres.auth.username | string | `"keycloak"` |  |
+| keycloakPostgres.enabled | bool | `true` |  |
+| keycloakPostgres.fullnameOverride | string | `""` |  |
+| keycloakPostgres.image.repository | string | `"bitnamilegacy/postgresql"` |  |
+| keycloakPostgres.primary.persistence.enabled | bool | `true` |  |
+| keycloakPostgres.primary.persistence.size | string | `"1Gi"` |  |
+| keycloakPostgres.primary.resources.limits.cpu | string | `"200m"` |  |
+| keycloakPostgres.primary.resources.limits.memory | string | `"256Mi"` |  |
+| keycloakPostgres.primary.resources.requests.cpu | string | `"100m"` |  |
+| keycloakPostgres.primary.resources.requests.memory | string | `"128Mi"` |  |
 | nameOverride | string | `""` |  |
-| postgres.auth.database | string | `"keycloak"` |  |
-| postgres.auth.existingSecret | string | `"{{ include \"lifecycle-keycloak.postgresSecretName\" . }}"` |  |
-| postgres.auth.secretKeys.adminPasswordKey | string | `"POSTGRES_ADMIN_PASSWORD"` |  |
-| postgres.auth.secretKeys.userPasswordKey | string | `"POSTGRES_USER_PASSWORD"` |  |
-| postgres.auth.username | string | `"keycloak"` |  |
-| postgres.enabled | bool | `true` |  |
-| postgres.fullnameOverride | string | `""` |  |
-| postgres.image.repository | string | `"bitnamilegacy/postgresql"` |  |
-| postgres.primary.persistence.enabled | bool | `true` |  |
-| postgres.primary.persistence.size | string | `"1Gi"` |  |
-| postgres.primary.resources.limits.cpu | string | `"200m"` |  |
-| postgres.primary.resources.limits.memory | string | `"256Mi"` |  |
-| postgres.primary.resources.requests.cpu | string | `"100m"` |  |
-| postgres.primary.resources.requests.memory | string | `"128Mi"` |  |
+| parentChartName | string | `"lifecycle"` |  |
 | realm | string | `"lifecycle"` |  |
 | realmDisplayName | string | `"Lifecycle"` |  |
 | secrets.bootstrapAdmin.annotations | list | `[]` |  |

--- a/charts/lifecycle-keycloak/templates/_helpers.tpl
+++ b/charts/lifecycle-keycloak/templates/_helpers.tpl
@@ -76,11 +76,8 @@ Namespace Hostname
 {{- if .Values.secrets.bootstrapAdmin.fullnameOverride -}}
     {{- .Values.secrets.bootstrapAdmin.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-    {{- if contains "lifecycle-keycloak" .Release.Name -}}
-        {{- printf "%s-%s" .Release.Name "bootstrap-admin" | trunc 63 | trimSuffix "-" -}}
-    {{- else -}}
-        {{- printf "%s-%s-%s" .Release.Name "lifecycle-keycloak" "bootstrap-admin" | trunc 63 | trimSuffix "-" -}}
-    {{- end -}}
+    {{- $prefix := include "lifecycle-keycloak.fullname" . -}}
+    {{- printf "%s-%s" $prefix "bootstrap-admin" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 
@@ -88,11 +85,8 @@ Namespace Hostname
 {{- if .Values.secrets.githubIdp.fullnameOverride -}}
     {{- .Values.secrets.githubIdp.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-    {{- if contains "lifecycle-keycloak" .Release.Name -}}
-        {{- printf "%s-%s" .Release.Name "github-idp" | trunc 63 | trimSuffix "-" -}}
-    {{- else -}}
-        {{- printf "%s-%s-%s" .Release.Name "lifecycle-keycloak" "github-idp" | trunc 63 | trimSuffix "-" -}}
-    {{- end -}}
+    {{- $prefix := include "lifecycle-keycloak.fullname" . -}}
+    {{- printf "%s-%s" $prefix "github-idp" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 
@@ -100,14 +94,23 @@ Namespace Hostname
 {{- if contains "lifecycle-keycloak" .Release.Name }}
     {{- printf "%s-%s" .Release.Name "postgres" | trunc 63 | trimSuffix "-" }}
 {{- else }}
-    {{- printf "%s-%s-%s" .Release.Name "lifecycle-keycloak" "postgres" | trunc 63 | trimSuffix "-" }}
+    {{- printf "%s-%s-%s" .Release.Name "keycloak" "postgres" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end -}}
 
 {{- define "lifecycle-keycloak.postgresSvcPrefix" -}}
-{{- if .Values.postgres.fullnameOverride }}
-    {{- printf "%s.%s" .Values.postgres.fullnameOverride (include "lifecycle-keycloak.namespaceHostname" .) }}
+{{- if .Values.keycloakPostgres.fullnameOverride }}
+    {{- printf "%s.%s" .Values.keycloakPostgres.fullnameOverride (include "lifecycle-keycloak.namespaceHostname" .) }}
 {{- else }}
-    {{- printf "%s-%s.%s" .Release.Name "postgres" (include "lifecycle-keycloak.namespaceHostname" .) }}
+    {{- $prefix := include "lifecycle-keycloak.fullname" . -}}
+    {{- printf "%s-%s.%s" $prefix "postgres" (include "lifecycle-keycloak.namespaceHostname" .) -}}
 {{- end }}
+{{- end -}}
+
+{{- define "lifecycle-keycloak.parentChartPrefix" -}}
+{{- if contains .Values.parentChartName .Release.Name -}}
+    {{- .Release.Name -}}
+{{- else -}}
+    {{- printf "%s-%s" .Release.Name .Values.parentChartName -}}
+{{- end -}}
 {{- end -}}

--- a/charts/lifecycle-keycloak/templates/keycloak-idp-secrets.yaml
+++ b/charts/lifecycle-keycloak/templates/keycloak-idp-secrets.yaml
@@ -18,7 +18,7 @@ limitations under the License.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: keycloak-idp-secrets
+  name: {{ include "lifecycle-keycloak.fullname" . }}-idp-secrets
   namespace: {{ .Release.Namespace }}
 data:
   company_idp_client_id: "{{ print "company-idp-" (randNumeric 10) | b64enc }}"

--- a/charts/lifecycle-keycloak/templates/keycloak-instance.yaml
+++ b/charts/lifecycle-keycloak/templates/keycloak-instance.yaml
@@ -32,7 +32,7 @@ spec:
     vendor: postgres
     host: {{ include "lifecycle-keycloak.postgresSvcPrefix" . | quote }}
     port: 5432
-    database: {{ .Values.postgres.auth.database | quote }}
+    database: {{ .Values.keycloakPostgres.auth.database | quote }}
     usernameSecret:
       name: {{ include "lifecycle-keycloak.postgresSecretName" . | quote }}
       key: POSTGRES_USERNAME
@@ -85,7 +85,7 @@ spec:
               - name: GITHUB_CLIENT_ID
                 valueFrom:
                   secretKeyRef:
-                    name: {{ tpl (.Values.githubIdp.clientId.secretKeyRef.name | default (include "lifecycle-keycloak.githubIdpSecretName" .)) $ | quote }}
+                    name: {{ tpl (.Values.githubIdp.clientId.secretKeyRef.name | default (include "lifecycle-keycloak.githubIdpSecretName" .)) . | quote }}
                     key: {{ .Values.githubIdp.clientId.secretKeyRef.key | default "clientId" | quote }}
             volumeMounts:
               - name: vault-volume
@@ -98,7 +98,7 @@ spec:
             projected:
               sources:
                 - secret:
-                    name: {{ tpl (.Values.githubIdp.clientSecret.secretKeyRef.name | default (include "lifecycle-keycloak.githubIdpSecretName" .)) $ | quote }}
+                    name: {{ tpl (.Values.githubIdp.clientSecret.secretKeyRef.name | default (include "lifecycle-keycloak.githubIdpSecretName" .)) . | quote }}
                     items:
                       - key: {{ .Values.githubIdp.clientSecret.secretKeyRef.key | default "clientSecret" | quote }}
                         path: github-client-secret

--- a/charts/lifecycle-keycloak/templates/postgres-secret.yaml
+++ b/charts/lifecycle-keycloak/templates/postgres-secret.yaml
@@ -43,7 +43,7 @@ metadata:
   {{- end }}
 type: Opaque
 stringData:
-  POSTGRES_USERNAME: {{ $.Values.postgres.auth.username | quote }}
+  POSTGRES_USERNAME: {{ $.Values.keycloakPostgres.auth.username | quote }}
 data:
   {{- with . }}
   POSTGRES_ADMIN_PASSWORD: {{ .adminPassword | default (randAlphaNum 40) | b64enc | quote }}

--- a/charts/lifecycle-keycloak/values.yaml
+++ b/charts/lifecycle-keycloak/values.yaml
@@ -15,6 +15,8 @@
 nameOverride: ""
 fullnameOverride: ""
 
+parentChartName: lifecycle
+
 annotations: {}
 extraLabels: {}
 
@@ -101,7 +103,7 @@ secrets:
     clientSecret:
 
 
-postgres:
+keycloakPostgres:
   enabled: true
   fullnameOverride: ""
 


### PR DESCRIPTION
- Replace redundant naming logic with lifecycle-keycloak.fullname
- Add parentChartPrefix helper to handle custom release names
- Fix tpl scope in keycloak-instance.yaml from $ to .
- Rename postgres values to keycloakPostgres to prevent collisions