### PR TITLE
feat(lifecycle): integrate `lifecycle-keycloak` as a subchart

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ A collection of Helm charts primarily used for **Lifecycle** application deploym
 | Chart | Version | App Version | Description |
 | :--- | :--- | :--- | :--- |
 | [keycloak-operator](./charts/keycloak-operator) | `0.1.0` | `26.4.7` | Helm chart for Keycloak operator based on the [official manifests](https://www.keycloak.org/operator/installation#_installing_by_using_kubectl_without_operator_lifecycle_manager) |
-| [lifecycle](./charts/lifecycle) | `0.4.0` | `0.1.11` | A Helm umbrella chart for full Lifecycle stack |
+| [lifecycle](./charts/lifecycle) | `0.5.0` | `0.1.11` | A Helm umbrella chart for full Lifecycle stack |
 | [lifecycle-keycloak](./charts/lifecycle-keycloak) | `0.5.0` | `0.0.0` | Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports |
 | [lifecycle-ui](./charts/lifecycle-ui) | `0.2.0` | `0.1.2` | A Helm chart for Lifecycle UI (Next.js) |

--- a/charts/lifecycle/Chart.yaml
+++ b/charts/lifecycle/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: lifecycle
 description: A Helm umbrella chart for full Lifecycle stack
 type: application
-version: 0.4.0
+version: 0.5.0
 appVersion: 0.1.11
 
 dependencies:
@@ -47,3 +47,10 @@ dependencies:
     version: 0.10.0
     repository: "https://andrcuns.github.io/charts"
     condition: buildkit.enabled
+
+  # lifecycle-keycloak (Keycloak instance for Lifecycle) Dependency
+  - name: lifecycle-keycloak
+    alias: keycloak
+    version: 0.5.0
+    repository: "https://goodrxoss.github.io/helm-charts"
+    condition: keycloak.enabled

--- a/charts/lifecycle/README.md
+++ b/charts/lifecycle/README.md
@@ -1,6 +1,6 @@
 # lifecycle
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.1.11](https://img.shields.io/badge/AppVersion-0.1.11-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.1.11](https://img.shields.io/badge/AppVersion-0.1.11-informational?style=flat-square)
 
 A Helm umbrella chart for full Lifecycle stack
 
@@ -40,7 +40,7 @@ buildkit:
 ```bash
 helm upgrade -i lifecycle \
   oci://ghcr.io/goodrxoss/helm-charts/lifecycle \
-  --version 0.4.0 \
+  --version 0.5.0 \
   -f values.yaml \
   -n lifecycle-app \
   --create-namespace
@@ -53,6 +53,7 @@ helm upgrade -i lifecycle \
 | https://andrcuns.github.io/charts | buildkit(buildkit-service) | 0.10.0 |
 | https://charts.bitnami.com/bitnami | postgres(postgresql) | 15.5.19 |
 | https://charts.bitnami.com/bitnami | redis(redis) | 19.6.3 |
+| https://goodrxoss.github.io/helm-charts | keycloak(lifecycle-keycloak) | 0.5.0 |
 | https://jouve.github.io/charts | distribution(distribution) | 0.1.7 |
 
 ## Values
@@ -197,6 +198,14 @@ helm upgrade -i lifecycle \
 | global.serviceAccount.annotations | list | `[]` |  |
 | global.serviceAccount.create | bool | `true` |  |
 | global.serviceAccount.name | string | `""` |  |
+| keycloak.clients.lifecycleUi.url | string | `"https://ui.example.com"` |  |
+| keycloak.enabled | bool | `true` |  |
+| keycloak.githubIdp.clientId.secretKeyRef.key | string | `"GITHUB_CLIENT_ID"` |  |
+| keycloak.githubIdp.clientId.secretKeyRef.name | string | `"{{ include \"lifecycle-keycloak.parentChartPrefix\" . }}-bootstrap"` |  |
+| keycloak.githubIdp.clientSecret.secretKeyRef.key | string | `"GITHUB_CLIENT_SECRET"` |  |
+| keycloak.githubIdp.clientSecret.secretKeyRef.name | string | `"{{ include \"lifecycle-keycloak.parentChartPrefix\" . }}-bootstrap"` |  |
+| keycloak.hostname | string | `"https://auth.example.com"` |  |
+| keycloak.keycloakPostgres.nameOverride | string | `"keycloak-postgres"` |  |
 | postgres.auth.database | string | `"lifecycle"` |  |
 | postgres.auth.existingSecret | string | `"{{ include \"..helper.postgresSecretName\" . }}"` |  |
 | postgres.auth.secretKeys.adminPasswordKey | string | `"POSTGRES_ADMIN_PASSWORD"` |  |

--- a/charts/lifecycle/values.yaml
+++ b/charts/lifecycle/values.yaml
@@ -325,3 +325,24 @@ buildkit:
     requests:
       cpu: "500m"
       memory: "1Gi"
+
+keycloak:
+  enabled: true
+  hostname: https://auth.example.com
+
+  clients:
+    lifecycleUi:
+      url: https://ui.example.com
+
+  githubIdp:
+    clientId:
+      secretKeyRef:
+        name: '{{ include "lifecycle-keycloak.parentChartPrefix" . }}-bootstrap'
+        key: GITHUB_CLIENT_ID
+    clientSecret:
+      secretKeyRef:
+        name: '{{ include "lifecycle-keycloak.parentChartPrefix" . }}-bootstrap'
+        key: GITHUB_CLIENT_SECRET
+
+  keycloakPostgres:
+    nameOverride: keycloak-postgres


### PR DESCRIPTION
- Add `lifecycle-keycloak` to Chart.yaml with `keycloak` alias
- Configure keycloak.enabled condition
- Set up dynamic GitHub IDP secret names using parentChartPrefix helper
- Align postgres naming with keycloakPostgres.nameOverride
- Set default hostnames for Keycloak and UI clients