### PR TITLE
fix(lifecycle-keycloak): align postgres resource naming after dependency aliasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ A collection of Helm charts primarily used for **Lifecycle** application deploym
 | :--- | :--- | :--- | :--- |
 | [keycloak-operator](./charts/keycloak-operator) | `0.1.0` | `26.4.7` | Helm chart for Keycloak operator based on the [official manifests](https://www.keycloak.org/operator/installation#_installing_by_using_kubectl_without_operator_lifecycle_manager) |
 | [lifecycle](./charts/lifecycle) | `0.5.0` | `0.1.11` | A Helm umbrella chart for full Lifecycle stack |
-| [lifecycle-keycloak](./charts/lifecycle-keycloak) | `0.5.0` | `0.0.0` | Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports |
+| [lifecycle-keycloak](./charts/lifecycle-keycloak) | `0.5.1` | `0.0.0` | Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports |
 | [lifecycle-ui](./charts/lifecycle-ui) | `0.2.0` | `0.1.2` | A Helm chart for Lifecycle UI (Next.js) |

--- a/charts/lifecycle-keycloak/Chart.yaml
+++ b/charts/lifecycle-keycloak/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: lifecycle-keycloak
 description: Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports
 type: application
-version: 0.5.0
+version: 0.5.1
 appVersion: 0.0.0
 home: https://goodrxoss.github.io/helm-charts/charts/lifecycle-keycloak/
 

--- a/charts/lifecycle-keycloak/README.md
+++ b/charts/lifecycle-keycloak/README.md
@@ -1,6 +1,6 @@
 # lifecycle-keycloak
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports
 
@@ -128,7 +128,7 @@ This chart uses the `KeycloakRealmImport` resource for the initial setup.
 ```shell
 helm upgrade -i lifecycle-keycloak \
   oci://ghcr.io/goodrxoss/helm-charts/lifecycle-keycloak \
-  --version 0.5.0 \
+  --version 0.5.1 \
   -f values.yaml \
   -n lifecycle-keycloak \
   --create-namespace
@@ -185,6 +185,7 @@ helm upgrade -i lifecycle-keycloak \
 | keycloakPostgres.enabled | bool | `true` |  |
 | keycloakPostgres.fullnameOverride | string | `""` |  |
 | keycloakPostgres.image.repository | string | `"bitnamilegacy/postgresql"` |  |
+| keycloakPostgres.nameOverride | string | `"postgres"` |  |
 | keycloakPostgres.primary.persistence.enabled | bool | `true` |  |
 | keycloakPostgres.primary.persistence.size | string | `"1Gi"` |  |
 | keycloakPostgres.primary.resources.limits.cpu | string | `"200m"` |  |

--- a/charts/lifecycle-keycloak/values.yaml
+++ b/charts/lifecycle-keycloak/values.yaml
@@ -105,6 +105,7 @@ secrets:
 
 keycloakPostgres:
   enabled: true
+  nameOverride: postgres
   fullnameOverride: ""
 
   # Values passed directly to the bitnami/postgresql subchart.


### PR DESCRIPTION
#### **Description**

This PR fixes a naming conflict introduced by aliasing the PostgreSQL dependency to `keycloakPostgres`. Without this fix, Helm generates resource names and hostnames using the alias (e.g., `lifecycle-keycloakPostgres`), which breaks internal service discovery and deviates from our established naming conventions.

#### **The Problem**

In Helm, when a dependency is aliased (e.g., `name: postgres, alias: keycloakPostgres`), the alias becomes the default `.Chart.Name` for that subchart's context. This caused:

1. **Service names** to change to `*-keycloakPostgres`, breaking Keycloak's database connection strings.
2. **Pod labels** to change, potentially affecting NetworkPolicies and Monitoring.
3. **Inconsistent naming** compared to other environment components.

#### **Key Changes**

* **Enforced Naming:** Added `nameOverride: postgres` specifically for the `keycloakPostgres` block.
* **Result:** This forces the subchart to generate resources as `*-postgres` while still allowing us to keep the unique `keycloakPostgres` key in `values.yaml` to avoid collisions with other database instances in the same umbrella chart.