### PR TITLE
feat(lifecycle-ui): add external secret support and subchart prefixing logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ A collection of Helm charts primarily used for **Lifecycle** application deploym
 | [keycloak-operator](./charts/keycloak-operator) | `0.1.0` | `26.4.7` | Helm chart for Keycloak operator based on the [official manifests](https://www.keycloak.org/operator/installation#_installing_by_using_kubectl_without_operator_lifecycle_manager) |
 | [lifecycle](./charts/lifecycle) | `0.5.0` | `0.1.11` | A Helm umbrella chart for full Lifecycle stack |
 | [lifecycle-keycloak](./charts/lifecycle-keycloak) | `0.6.0` | `0.0.0` | Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports |
-| [lifecycle-ui](./charts/lifecycle-ui) | `0.2.0` | `0.1.2` | A Helm chart for Lifecycle UI (Next.js) |
+| [lifecycle-ui](./charts/lifecycle-ui) | `0.3.0` | `0.1.2` | A Helm chart for Lifecycle UI (Next.js) |

--- a/charts/lifecycle-ui/Chart.yaml
+++ b/charts/lifecycle-ui/Chart.yaml
@@ -16,6 +16,6 @@ apiVersion: v2
 name: lifecycle-ui
 description: A Helm chart for Lifecycle UI (Next.js)
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: 0.1.2
 home: https://goodrxoss.github.io/helm-charts/charts/lifecycle-ui/

--- a/charts/lifecycle-ui/README.md
+++ b/charts/lifecycle-ui/README.md
@@ -1,6 +1,6 @@
 # lifecycle-ui
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.1.2](https://img.shields.io/badge/AppVersion-0.1.2-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.1.2](https://img.shields.io/badge/AppVersion-0.1.2-informational?style=flat-square)
 
 A Helm chart for Lifecycle UI (Next.js)
 
@@ -41,7 +41,7 @@ config:
 ```bash
 helm upgrade -i lifecycle-ui \
   oci://ghcr.io/goodrxoss/helm-charts/lifecycle-ui \
-  --version 0.2.0 \
+  --version 0.3.0 \
   -f values.yaml \
   -n lifecycle-ui \
   --create-namespace
@@ -108,8 +108,12 @@ deployment:
 | config.apiUrl | string | `""` |  |
 | config.appUrl | string | `""` |  |
 | config.authBaseUrl | string | `""` |  |
-| config.authClientId | string | `""` |  |
+| config.authClientId | string | `"lifecycle-ui"` |  |
+| config.authClientSecret.secretKeyRef.key | string | `nil` |  |
+| config.authClientSecret.secretKeyRef.name | string | `nil` |  |
 | config.authRealm | string | `""` |  |
+| config.authSecret.secretKeyRef.key | string | `nil` |  |
+| config.authSecret.secretKeyRef.name | string | `nil` |  |
 | config.enabled | bool | `true` |  |
 | config.fullnameOverride | string | `""` |  |
 | deployment.affinity | object | `{}` |  |
@@ -156,6 +160,7 @@ deployment:
 | ingress.hosts | list | `[]` |  |
 | ingress.tls | list | `[]` |  |
 | nameOverride | string | `""` |  |
+| parentChartName | string | `"lifecycle"` |  |
 | pdb.enabled | bool | `false` |  |
 | pdb.minAvailable | int | `1` |  |
 | podSecurityContext.fsGroup | int | `2000` |  |

--- a/charts/lifecycle-ui/templates/_helpers.tpl
+++ b/charts/lifecycle-ui/templates/_helpers.tpl
@@ -89,11 +89,11 @@ Create the name of the service account to use
 {{/*
 Create the name of the secret
 */}}
-{{- define "lifecycle-ui.helper.secretName" -}}
+{{- define "lifecycle-ui.helper.authSecretName" -}}
 {{- if .Values.secrets.fullnameOverride }}
     {{- .Values.secrets.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-    {{- printf "%s-%s" (include "lifecycle-ui.helper.fullname" .) "secrets" | trunc 63 | trimSuffix "-" }}
+    {{- printf "%s-%s" (include "lifecycle-ui.helper.fullname" .) "auth" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
 
@@ -107,3 +107,11 @@ Create the name of the configmap
     {{- printf "%s-%s" (include "lifecycle-ui.helper.fullname" .) "config" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
+
+{{- define "lifecycle-ui.parentChartPrefix" -}}
+{{- if contains .Values.parentChartName .Release.Name -}}
+    {{- .Release.Name -}}
+{{- else -}}
+    {{- printf "%s-%s" .Release.Name .Values.parentChartName -}}
+{{- end -}}
+{{- end -}}

--- a/charts/lifecycle-ui/templates/deployment.yaml
+++ b/charts/lifecycle-ui/templates/deployment.yaml
@@ -91,14 +91,20 @@ spec:
           env:
             - name: HELM_RELEASE_NAME
               value: {{ .Release.Name }}
+            - name: NEXTAUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ tpl (.Values.config.authSecret.secretKeyRef.name | default (include "lifecycle-ui.helper.authSecretName" .)) . | quote }}
+                  key: {{ .Values.config.authSecret.secretKeyRef.key | default "authSecret" | quote }}
+            - name: KEYCLOAK_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ tpl (.Values.config.authClientSecret.secretKeyRef.name | default (include "lifecycle-ui.helper.authSecretName" .)) . | quote }}
+                  key: {{ .Values.config.authClientSecret.secretKeyRef.key | default "authClientSecret" | quote }}
             {{- with .Values.deployment.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           envFrom:
-            {{- if .Values.secrets.enabled }}
-            - secretRef:
-                name: {{ include "lifecycle-ui.helper.secretName" . }}
-            {{- end }}
             {{- if .Values.config.enabled }}
             - configMapRef:
                 name: {{ include "lifecycle-ui.helper.configName" . }}

--- a/charts/lifecycle-ui/templates/secret-ui.yaml
+++ b/charts/lifecycle-ui/templates/secret-ui.yaml
@@ -15,7 +15,7 @@ limitations under the License.
 */}}
 
 {{- $namespace := .Release.Namespace -}}
-{{- $secretName := include "lifecycle-ui.helper.secretName" . -}}
+{{- $secretName := include "lifecycle-ui.helper.authSecretName" . -}}
 {{- $apiVersion := "v1" -}}
 
 {{- if and .Values.secrets.enabled .Release.IsInstall (not (lookup $apiVersion "Secret" $namespace $secretName)) }}
@@ -36,7 +36,7 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  NEXTAUTH_SECRET: {{ .authSecret | default (randAlphaNum 64) | b64enc | quote }}
-  KEYCLOAK_CLIENT_SECRET: {{ .authClientSecret | default (randAlphaNum 40) | b64enc | quote }}
+  authSecret: {{ .authSecret | default (randAlphaNum 64) | b64enc | quote }}
+  authClientSecret: {{ .authClientSecret | default (randAlphaNum 40) | b64enc | quote }}
 {{- end -}}
 {{- end -}}

--- a/charts/lifecycle-ui/values.yaml
+++ b/charts/lifecycle-ui/values.yaml
@@ -24,6 +24,7 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+parentChartName: lifecycle
 extraLabels: {}
 
 serviceAccount:
@@ -132,4 +133,12 @@ config:
 
   authBaseUrl: ""
   authRealm: ""
-  authClientId: ""
+  authSecret:
+    secretKeyRef:
+      name:  # fallback to "{{ include "lifecycle-ui.helper.authSecretName" . }}"
+      key:  # default "authSecret"
+  authClientId: "lifecycle-ui"
+  authClientSecret:
+    secretKeyRef:
+      name:  # fallback to "{{ include "lifecycle-ui.helper.authSecretName" . }}"
+      key:  # default "authClientSecret"


### PR DESCRIPTION
### Description

#### **Summary**

This PR introduces significant enhancements to the **lifecycle-ui** Helm chart by implementing support for external secrets and improving integration when used as a subchart. These changes provide a more secure approach to sensitive data management by allowing the use of pre-existing Kubernetes secrets or external secret operators.

#### **Key Changes**

* **External Secrets Support**:
  * Transitioned from `envFrom` (loading all keys) to specific `valueFrom.secretKeyRef` for `NEXTAUTH_SECRET` and `KEYCLOAK_CLIENT_SECRET`.
  * Added `tpl` function support for secret names, enabling dynamic referencing of external secrets via `values.yaml`.


* **Subchart Integration**:
  * Added a new helper `lifecycle-ui.parentChartPrefix` to handle naming conventions when the chart is deployed as a dependency.
  * Ensures consistent resource naming by checking `parentChartName` against the `Release.Name`.