### PR TITLE
feat(lifecycle-keycloak): add support for external database connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ A collection of Helm charts primarily used for **Lifecycle** application deploym
 | :--- | :--- | :--- | :--- |
 | [keycloak-operator](./charts/keycloak-operator) | `0.1.0` | `26.4.7` | Helm chart for Keycloak operator based on the [official manifests](https://www.keycloak.org/operator/installation#_installing_by_using_kubectl_without_operator_lifecycle_manager) |
 | [lifecycle](./charts/lifecycle) | `0.6.0` | `0.1.11` | A Helm umbrella chart for full Lifecycle stack |
-| [lifecycle-keycloak](./charts/lifecycle-keycloak) | `0.6.0` | `0.0.0` | Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports |
+| [lifecycle-keycloak](./charts/lifecycle-keycloak) | `0.7.0` | `0.0.0` | Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports |
 | [lifecycle-ui](./charts/lifecycle-ui) | `0.3.0` | `0.1.2` | A Helm chart for Lifecycle UI (Next.js) |

--- a/charts/lifecycle-keycloak/Chart.yaml
+++ b/charts/lifecycle-keycloak/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: lifecycle-keycloak
 description: Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports
 type: application
-version: 0.6.0
+version: 0.7.0
 appVersion: 0.0.0
 home: https://goodrxoss.github.io/helm-charts/charts/lifecycle-keycloak/
 
@@ -29,4 +29,4 @@ dependencies:
     alias: keycloakPostgres
     version: 15.5.19
     repository: "https://charts.bitnami.com/bitnami"
-    condition: postgres.enabled
+    condition: keycloakPostgres.enabled

--- a/charts/lifecycle-keycloak/README.md
+++ b/charts/lifecycle-keycloak/README.md
@@ -1,6 +1,6 @@
 # lifecycle-keycloak
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports
 
@@ -128,7 +128,7 @@ This chart uses the `KeycloakRealmImport` resource for the initial setup.
 ```shell
 helm upgrade -i lifecycle-keycloak \
   oci://ghcr.io/goodrxoss/helm-charts/lifecycle-keycloak \
-  --version 0.6.0 \
+  --version 0.7.0 \
   -f values.yaml \
   -n lifecycle-keycloak \
   --create-namespace
@@ -152,6 +152,14 @@ helm upgrade -i lifecycle-keycloak \
 | companyIdp.enabled | bool | `true` |  |
 | companyIdp.jwksUrl | string | `nil` |  |
 | companyIdp.tokenUrl | string | `nil` |  |
+| externalDatabase.database | string | `"keycloak"` |  |
+| externalDatabase.enabled | bool | `false` |  |
+| externalDatabase.host | string | `nil` |  |
+| externalDatabase.password.secretKeyRef.key | string | `nil` |  |
+| externalDatabase.password.secretKeyRef.name | string | `nil` |  |
+| externalDatabase.port | int | `5432` |  |
+| externalDatabase.username | string | `"keycloak"` |  |
+| externalDatabase.vendor | string | `"postgres"` |  |
 | extraLabels | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
 | githubIdp.clientId.secretKeyRef.key | string | `nil` |  |

--- a/charts/lifecycle-keycloak/templates/keycloak-instance.yaml
+++ b/charts/lifecycle-keycloak/templates/keycloak-instance.yaml
@@ -29,6 +29,15 @@ spec:
     user:
       secret: {{ include "lifecycle-keycloak.bootstrapAdminSecretName" . | quote }}
   db:
+  {{- if .Values.externalDatabase.enabled }}
+    vendor: {{ .Values.externalDatabase.vendor | quote }}
+    host: {{ .Values.externalDatabase.host | quote }}
+    port: {{ .Values.externalDatabase.port }}
+    database: {{ .Values.externalDatabase.database | quote }}
+    passwordSecret:
+      name: {{ .Values.externalDatabase.password.secretKeyRef.name | quote }}
+      key: {{ .Values.externalDatabase.password.secretKeyRef.key | quote }}
+  {{- else }}
     vendor: postgres
     host: {{ include "lifecycle-keycloak.postgresSvcPrefix" . | quote }}
     port: 5432
@@ -39,6 +48,7 @@ spec:
     passwordSecret:
       name: {{ include "lifecycle-keycloak.postgresSecretName" . | quote }}
       key: POSTGRES_USER_PASSWORD
+  {{- end }}
 
   http:
     httpEnabled: true
@@ -49,6 +59,10 @@ spec:
     backchannelDynamic: false
 
   additionalOptions:
+  {{- if .Values.externalDatabase.enabled }}
+    - name: db-username
+      value: {{ .Values.externalDatabase.username | quote }}
+  {{- end }}
     - name: hostname-strict-backchannel
       value: "false"
     - name: proxy-headers

--- a/charts/lifecycle-keycloak/values.yaml
+++ b/charts/lifecycle-keycloak/values.yaml
@@ -84,6 +84,18 @@ ingress:
   className: nginx
   tls: false
 
+externalDatabase:
+  enabled: false
+  vendor: postgres
+  host:
+  port: 5432
+  database: keycloak
+  username: keycloak
+  password:
+    secretKeyRef:
+      name:
+      key:
+
 secrets:
   bootstrapAdmin:
     enabled: true


### PR DESCRIPTION
### Summary

This PR introduces the ability to configure an **external database** for Keycloak via Helm values. Previously, the chart was limited to internal/predefined Postgres configurations.

### 🛠 Configuration Example (`values.yaml`)

To use an external database, configure the following section:

```yaml
externalDatabase:
  enabled: true
  vendor: postgres
  host: "db.production.example.com"
  port: 5432
  database: keycloak_prod
  username: keycloak_user
  password:
    secretKeyRef:
      name: my-db-secret
      key: password

```