### PR TITLE
feat(lifecycle): add MinIO subchart with secure credential architecture for log archival (v0.8.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ A collection of Helm charts primarily used for **Lifecycle** application deploym
 | Chart | Version | App Version | Description |
 | :--- | :--- | :--- | :--- |
 | [keycloak-operator](./charts/keycloak-operator) | `0.1.0` | `26.4.7` | Helm chart for Keycloak operator based on the [official manifests](https://www.keycloak.org/operator/installation#_installing_by_using_kubectl_without_operator_lifecycle_manager) |
-| [lifecycle](./charts/lifecycle) | `0.7.0` | `0.1.11` | A Helm umbrella chart for full Lifecycle stack |
+| [lifecycle](./charts/lifecycle) | `0.8.0` | `0.1.11` | A Helm umbrella chart for full Lifecycle stack |
 | [lifecycle-keycloak](./charts/lifecycle-keycloak) | `0.7.0` | `0.0.0` | Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports |
 | [lifecycle-ui](./charts/lifecycle-ui) | `0.3.0` | `0.1.2` | A Helm chart for Lifecycle UI (Next.js) |

--- a/charts/lifecycle/Chart.yaml
+++ b/charts/lifecycle/Chart.yaml
@@ -65,6 +65,6 @@ dependencies:
   # MinIO (S3-compatible object store for log archival)
   - name: minio
     alias: minio
-    version: 14.8.5
+    version: 17.0.21
     repository: "https://charts.bitnami.com/bitnami"
     condition: minio.enabled

--- a/charts/lifecycle/Chart.yaml
+++ b/charts/lifecycle/Chart.yaml
@@ -61,3 +61,10 @@ dependencies:
     version: 0.3.0
     repository: "https://goodrxoss.github.io/helm-charts"
     condition: ui.enabled
+
+  # MinIO (S3-compatible object store for log archival)
+  - name: minio
+    alias: minio
+    version: 14.8.5
+    repository: "https://charts.bitnami.com/bitnami"
+    condition: minio.enabled

--- a/charts/lifecycle/Chart.yaml
+++ b/charts/lifecycle/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: lifecycle
 description: A Helm umbrella chart for full Lifecycle stack
 type: application
-version: 0.7.0
+version: 0.8.0
 appVersion: 0.1.11
 
 dependencies:

--- a/charts/lifecycle/README.md
+++ b/charts/lifecycle/README.md
@@ -51,6 +51,7 @@ helm upgrade -i lifecycle \
 | Repository | Name | Version |
 |------------|------|---------|
 | https://andrcuns.github.io/charts | buildkit(buildkit-service) | 0.10.0 |
+| https://charts.bitnami.com/bitnami | minio(minio) | 17.0.21 |
 | https://charts.bitnami.com/bitnami | postgres(postgresql) | 15.5.19 |
 | https://charts.bitnami.com/bitnami | redis(redis) | 19.6.3 |
 | https://goodrxoss.github.io/helm-charts | keycloak(lifecycle-keycloak) | 0.7.0 |
@@ -224,6 +225,30 @@ helm upgrade -i lifecycle \
 | keycloak.keycloakPostgres.enabled | bool | `true` |  |
 | keycloak.keycloakPostgres.nameOverride | string | `"keycloak-postgres"` |  |
 | keycloak.secrets.postgres.enabled | bool | `true` |  |
+| minio.auth.existingSecret | string | `"{{ include \"..helper.objectStoreSecretName\" . }}"` |  |
+| minio.auth.rootPasswordSecretKey | string | `"OBJECT_STORE_SECRET_KEY"` |  |
+| minio.auth.rootUserSecretKey | string | `"OBJECT_STORE_ACCESS_KEY"` |  |
+| minio.clientImage.repository | string | `"bitnamilegacy/minio-client"` |  |
+| minio.clientImage.tag | string | `"2025.7.23"` |  |
+| minio.console.image.repository | string | `"bitnamilegacy/minio-object-browser"` |  |
+| minio.console.image.tag | string | `"2.0.2-debian-12-r3"` |  |
+| minio.defaultBuckets | string | `"lifecycle-logs"` |  |
+| minio.enabled | bool | `false` |  |
+| minio.fullnameOverride | string | `""` |  |
+| minio.image.repository | string | `"bitnamilegacy/minio"` |  |
+| minio.image.tag | string | `"2025.7.23"` |  |
+| minio.persistence.enabled | bool | `true` |  |
+| minio.persistence.size | string | `"20Gi"` |  |
+| minio.resources.requests.cpu | string | `"100m"` |  |
+| minio.resources.requests.memory | string | `"256Mi"` |  |
+| minio.volumePermissions.image.repository | string | `"bitnamilegacy/os-shell"` |  |
+| minio.volumePermissions.image.tag | string | `"2025.7.23"` |  |
+| objectStore.bucket | string | `""` |  |
+| objectStore.endpoint | string | `""` |  |
+| objectStore.port | string | `"9000"` |  |
+| objectStore.region | string | `""` |  |
+| objectStore.type | string | `"minio"` |  |
+| objectStore.useSSL | string | `"false"` |  |
 | postgres.auth.database | string | `"lifecycle"` |  |
 | postgres.auth.existingSecret | string | `"{{ include \"..helper.postgresSecretName\" . }}"` |  |
 | postgres.auth.secretKeys.adminPasswordKey | string | `"POSTGRES_ADMIN_PASSWORD"` |  |
@@ -257,6 +282,11 @@ helm upgrade -i lifecycle \
 | secrets.common.annotations | list | `[]` |  |
 | secrets.common.enabled | bool | `true` |  |
 | secrets.common.fullnameOverride | string | `""` |  |
+| secrets.objectStore.accessKey | string | `""` |  |
+| secrets.objectStore.annotations | list | `[]` |  |
+| secrets.objectStore.enabled | bool | `true` |  |
+| secrets.objectStore.fullnameOverride | string | `""` |  |
+| secrets.objectStore.secretKey | string | `""` |  |
 | secrets.postgres.annotations | list | `[]` |  |
 | secrets.postgres.enabled | bool | `true` |  |
 | secrets.postgres.fullnameOverride | string | `""` |  |

--- a/charts/lifecycle/README.md
+++ b/charts/lifecycle/README.md
@@ -1,6 +1,6 @@
 # lifecycle
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.1.11](https://img.shields.io/badge/AppVersion-0.1.11-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.1.11](https://img.shields.io/badge/AppVersion-0.1.11-informational?style=flat-square)
 
 A Helm umbrella chart for full Lifecycle stack
 
@@ -40,7 +40,7 @@ buildkit:
 ```bash
 helm upgrade -i lifecycle \
   oci://ghcr.io/goodrxoss/helm-charts/lifecycle \
-  --version 0.7.0 \
+  --version 0.8.0 \
   -f values.yaml \
   -n lifecycle-app \
   --create-namespace

--- a/charts/lifecycle/templates/_helpers.tpl
+++ b/charts/lifecycle/templates/_helpers.tpl
@@ -120,3 +120,19 @@ Namespace Hostname
     {{- printf "tcp://%s-%s.%s:1234" .Release.Name "buildkit" (include "..helper.namespaceHostname" .) }}
 {{- end }}
 {{- end -}}
+
+{{- define "..helper.objectStoreSecretName" -}}
+{{- if contains "lifecycle" .Release.Name }}
+    {{- printf "%s-%s" .Release.Name "objectstore" | trunc 63 | trimSuffix "-" }}
+{{- else }}
+    {{- printf "%s-%s-%s" .Release.Name "lifecycle" "objectstore" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end -}}
+
+{{- define "..helper.minioSvcEndpoint" -}}
+{{- if .Values.minio.fullnameOverride }}
+    {{- .Values.minio.fullnameOverride }}
+{{- else }}
+    {{- printf "%s-%s" .Release.Name "minio" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end -}}

--- a/charts/lifecycle/templates/configmap.yaml
+++ b/charts/lifecycle/templates/configmap.yaml
@@ -23,7 +23,7 @@ metadata:
 {{- end }}
   namespace: {{ .Release.Namespace }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "0"
     "helm.sh/resource-policy": keep
 data:
@@ -40,10 +40,20 @@ data:
 {{- else }}
   SECRET_COMMON_NAME: {{ include "..helper.fullname" $ }}-common
 {{- end }}
-{{- if .Values.minio.enabled }}
-  MINIO_ENDPOINT: {{ include "..helper.fullname" $ }}-minio
-  MINIO_PORT: "9000"
-  MINIO_BUCKET: {{ .Values.minio.defaultBuckets | default "lifecycle-logs" }}
-  MINIO_USE_SSL: "false"
+{{- if and (eq .Values.objectStore.type "minio") .Values.minio.enabled }}
+  OBJECT_STORE_TYPE: minio
+  OBJECT_STORE_ENDPOINT: {{ .Values.objectStore.endpoint | default (include "..helper.minioSvcEndpoint" $) | quote }}
+  OBJECT_STORE_PORT: {{ .Values.objectStore.port | default "9000" | quote }}
+  OBJECT_STORE_BUCKET: {{ .Values.minio.defaultBuckets | quote }}
+  OBJECT_STORE_USE_SSL: {{ .Values.objectStore.useSSL | default "false" | quote }}
+{{- if and .Values.secrets.objectStore.fullnameOverride (ne .Values.secrets.objectStore.fullnameOverride "") }}
+  SECRET_OBJECT_STORE_NAME: {{ .Values.secrets.objectStore.fullnameOverride }}
+{{- else }}
+  SECRET_OBJECT_STORE_NAME: {{ include "..helper.objectStoreSecretName" $ }}
+{{- end }}
+{{- else if eq .Values.objectStore.type "s3" }}
+  OBJECT_STORE_TYPE: s3
+  OBJECT_STORE_REGION: {{ required "objectStore.region is required when objectStore.type is s3" .Values.objectStore.region | quote }}
+  OBJECT_STORE_BUCKET: {{ .Values.objectStore.bucket | quote }}
 {{- end }}
 {{- end -}}

--- a/charts/lifecycle/templates/configmap.yaml
+++ b/charts/lifecycle/templates/configmap.yaml
@@ -40,4 +40,10 @@ data:
 {{- else }}
   SECRET_COMMON_NAME: {{ include "..helper.fullname" $ }}-common
 {{- end }}
+{{- if .Values.minio.enabled }}
+  MINIO_ENDPOINT: {{ include "..helper.fullname" $ }}-minio
+  MINIO_PORT: "9000"
+  MINIO_BUCKET: {{ .Values.minio.defaultBuckets | default "lifecycle-logs" }}
+  MINIO_USE_SSL: "false"
+{{- end }}
 {{- end -}}

--- a/charts/lifecycle/templates/deployments.yaml
+++ b/charts/lifecycle/templates/deployments.yaml
@@ -194,6 +194,14 @@ spec:
                 name: {{ include "..helper.fullname" $ }}-common
               {{- end }}
           {{- end }}
+          {{- if $.Values.secrets.objectStore.enabled }}
+            - secretRef:
+              {{- if $.Values.secrets.objectStore.fullnameOverride }}
+                name: {{ $.Values.secrets.objectStore.fullnameOverride }}
+              {{- else }}
+                name: {{ include "..helper.objectStoreSecretName" $ }}
+              {{- end }}
+          {{- end }}
           {{- if $.Values.global.envFrom }}
             {{- toYaml $.Values.global.envFrom | nindent 12 }}
           {{- end }}

--- a/charts/lifecycle/templates/secret-objectstore.yaml
+++ b/charts/lifecycle/templates/secret-objectstore.yaml
@@ -1,0 +1,51 @@
+{{- /*
+Copyright 2025 GoodRx, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- $namespace := .Release.Namespace -}}
+{{- $secretName := "" -}}
+{{- $apiVersion := "v1" -}}
+{{- $component := "objectstore" -}}
+
+{{- if .Values.secrets.objectStore.fullnameOverride -}}
+  {{- $secretName = .Values.secrets.objectStore.fullnameOverride -}}
+{{- else -}}
+  {{- $secretName = printf "%s" (include "..helper.objectStoreSecretName" .) -}}
+{{- end -}}
+
+{{- if and .Values.secrets.objectStore.enabled .Release.IsInstall (not (lookup $apiVersion "Secret" $namespace $secretName)) }}
+{{- with .Values.secrets.objectStore -}}
+apiVersion: {{ $apiVersion }}
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ $namespace }}
+  labels:
+    {{- include "..helper.labels" (merge (dict "component" $component) $) | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "0"
+    "helm.sh/resource-policy": keep
+  {{- with .annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  {{- with . }}
+  OBJECT_STORE_ACCESS_KEY: {{ .accessKey | default (randAlphaNum 40) | b64enc | quote }}
+  OBJECT_STORE_SECRET_KEY: {{ .secretKey | default (randAlphaNum 40) | b64enc | quote }}
+  {{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/lifecycle/values.yaml
+++ b/charts/lifecycle/values.yaml
@@ -245,6 +245,13 @@ secrets:
     annotations: []
     redisPassword: ""
 
+  objectStore:
+    enabled: true
+    fullnameOverride: ""
+    annotations: []
+    accessKey: ""
+    secretKey: ""
+
 postgres:
   enabled: true
   fullnameOverride: ""
@@ -388,12 +395,37 @@ ui:
         name: '{{ include "lifecycle-ui.parentChartPrefix" . }}-keycloak-lifecycle-ui'
         key: clientSecret
 
+objectStore:
+  type: minio
+  # bucket is used for s3 mode; minio mode derives the bucket from minio.defaultBuckets
+  bucket: ""
+  region: ""
+  endpoint: ""
+  port: "9000"
+  useSSL: "false"
+
 minio:
   enabled: false
+  fullnameOverride: ""
   defaultBuckets: "lifecycle-logs"
   auth:
-    rootUser: minioadmin
-    rootPassword: minioadmin
+    existingSecret: '{{ include "..helper.objectStoreSecretName" . }}'
+    rootUserSecretKey: "OBJECT_STORE_ACCESS_KEY"
+    rootPasswordSecretKey: "OBJECT_STORE_SECRET_KEY"
+  image:
+    repository: bitnamilegacy/minio
+    tag: "2025.7.23"
+  clientImage:
+    repository: bitnamilegacy/minio-client
+    tag: "2025.7.23"
+  console:
+    image:
+      repository: bitnamilegacy/minio-object-browser
+      tag: "2.0.2-debian-12-r3"
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
+      tag: "2025.7.23"
   persistence:
     enabled: true
     size: 20Gi

--- a/charts/lifecycle/values.yaml
+++ b/charts/lifecycle/values.yaml
@@ -387,3 +387,17 @@ ui:
       secretKeyRef:
         name: '{{ include "lifecycle-ui.parentChartPrefix" . }}-keycloak-lifecycle-ui'
         key: clientSecret
+
+minio:
+  enabled: false
+  defaultBuckets: "lifecycle-logs"
+  auth:
+    rootUser: minioadmin
+    rootPassword: minioadmin
+  persistence:
+    enabled: true
+    size: 20Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi


### PR DESCRIPTION
## Goal

Build and deploy job logs are permanently lost when k8s Job pods are evicted or TTL-expired (~24h). This PR adds MinIO as an optional in-cluster S3-compatible object store so logs can be archived at job completion time and retrieved even after live pods are gone. It also supports AWS S3 via IRSA for production environments.

## Changes

| File | Change |
|------|--------|
| `Chart.yaml` | Add `minio 17.0.21` Bitnami subchart dependency (disabled by default); bump chart version → **0.8.0** |
| `values.yaml` | Add `objectStore:` section (type, endpoint, port, bucket, SSL, region); add `secrets.objectStore` section; add `minio:` subchart values; wire `minio.auth.existingSecret` to shared secret |
| `templates/secret-objectstore.yaml` | *(new)* Kubernetes Secret storing `OBJECT_STORE_ACCESS_KEY` and `OBJECT_STORE_SECRET_KEY`; shared by both the app and MinIO via `existingSecret` |
| `templates/configmap.yaml` | Emit `OBJECT_STORE_*` env vars (no credentials); guarded by `minio.enabled` flag; add `SECRET_OBJECT_STORE_NAME`; hook changed to `pre-install,pre-upgrade`; S3 mode validates required `region` |
| `templates/deployments.yaml` | Add `envFrom: secretRef` for `secrets.objectStore` — injects credentials into all pods automatically |
| `templates/_helpers.tpl` | Add `..helper.objectStoreSecretName` and `..helper.minioSvcEndpoint` helpers |

## Credential architecture

Credentials are **not in the ConfigMap**. They live exclusively in a Kubernetes Secret:

| ConfigMap | Secret (`<release>-objectstore`) |
|---|---|
| `OBJECT_STORE_TYPE` | `OBJECT_STORE_ACCESS_KEY` |
| `OBJECT_STORE_ENDPOINT` | `OBJECT_STORE_SECRET_KEY` |
| `OBJECT_STORE_PORT` | |
| `OBJECT_STORE_BUCKET` | |
| `OBJECT_STORE_USE_SSL` | |
| `SECRET_OBJECT_STORE_NAME` | |

The same secret is referenced by `minio.auth.existingSecret` — MinIO and the app share one credential source with no duplication.

## How it works

1. **Opt-in**: MinIO is disabled by default (`minio.enabled: false`). When disabled, the ConfigMap emits no `OBJECT_STORE_*` vars — no broken env vars pointing at a non-existent service.
2. **Credentials**: Stored in a dedicated Secret (created on install, `resource-policy: keep`). Set `secrets.objectStore.accessKey` / `secretKey` in your override values or let the chart generate random values.
3. **S3 mode**: Set `objectStore.type: s3` + `objectStore.region` for AWS S3 via IRSA — no static credentials needed.
4. **App-side gating**: The lifecycle backend checks `logArchival.enabled` in `global_config` before making any object store calls — enabling the subchart alone is safe.

## Rollout

```yaml
minio:
  enabled: true

secrets:
  objectStore:
    accessKey: <from-sealed-secret>
    secretKey: <from-sealed-secret>
```

Then activate archival via global_config:
```json
{ "logArchival": { "enabled": true, "retentionDays": 14 } }
```

## Test plan
- [ ] `helm template` with defaults (`minio.enabled=false`) — no `OBJECT_STORE_*` vars in ConfigMap
- [ ] `helm template --set minio.enabled=true` — ConfigMap has `OBJECT_STORE_*` (no credentials), Secret has `OBJECT_STORE_ACCESS_KEY`/`SECRET_KEY`, deployments have `envFrom: secretRef`
- [ ] `helm template --set objectStore.type=s3 --set objectStore.region=us-east-1` — ConfigMap has S3 vars only
- [ ] `helm template --set objectStore.type=s3` — fails with `objectStore.region is required` error
- [ ] In a test cluster: MinIO pod reaches `Running`, bucket `lifecycle-logs` auto-created, app pods have credentials available as env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)