### PR TITLE
feat: add external database support and bump chart version to 0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ A collection of Helm charts primarily used for **Lifecycle** application deploym
 | Chart | Version | App Version | Description |
 | :--- | :--- | :--- | :--- |
 | [keycloak-operator](./charts/keycloak-operator) | `0.1.0` | `26.4.7` | Helm chart for Keycloak operator based on the [official manifests](https://www.keycloak.org/operator/installation#_installing_by_using_kubectl_without_operator_lifecycle_manager) |
-| [lifecycle](./charts/lifecycle) | `0.6.0` | `0.1.11` | A Helm umbrella chart for full Lifecycle stack |
+| [lifecycle](./charts/lifecycle) | `0.7.0` | `0.1.11` | A Helm umbrella chart for full Lifecycle stack |
 | [lifecycle-keycloak](./charts/lifecycle-keycloak) | `0.7.0` | `0.0.0` | Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports |
 | [lifecycle-ui](./charts/lifecycle-ui) | `0.3.0` | `0.1.2` | A Helm chart for Lifecycle UI (Next.js) |

--- a/charts/lifecycle/Chart.yaml
+++ b/charts/lifecycle/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: lifecycle
 description: A Helm umbrella chart for full Lifecycle stack
 type: application
-version: 0.6.0
+version: 0.7.0
 appVersion: 0.1.11
 
 dependencies:
@@ -51,7 +51,7 @@ dependencies:
   # lifecycle-keycloak (Keycloak instance for Lifecycle) Dependency
   - name: lifecycle-keycloak
     alias: keycloak
-    version: 0.6.0
+    version: 0.7.0
     repository: "https://goodrxoss.github.io/helm-charts"
     condition: keycloak.enabled
 

--- a/charts/lifecycle/README.md
+++ b/charts/lifecycle/README.md
@@ -1,6 +1,6 @@
 # lifecycle
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.1.11](https://img.shields.io/badge/AppVersion-0.1.11-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.1.11](https://img.shields.io/badge/AppVersion-0.1.11-informational?style=flat-square)
 
 A Helm umbrella chart for full Lifecycle stack
 
@@ -40,7 +40,7 @@ buildkit:
 ```bash
 helm upgrade -i lifecycle \
   oci://ghcr.io/goodrxoss/helm-charts/lifecycle \
-  --version 0.6.0 \
+  --version 0.7.0 \
   -f values.yaml \
   -n lifecycle-app \
   --create-namespace
@@ -53,7 +53,7 @@ helm upgrade -i lifecycle \
 | https://andrcuns.github.io/charts | buildkit(buildkit-service) | 0.10.0 |
 | https://charts.bitnami.com/bitnami | postgres(postgresql) | 15.5.19 |
 | https://charts.bitnami.com/bitnami | redis(redis) | 19.6.3 |
-| https://goodrxoss.github.io/helm-charts | keycloak(lifecycle-keycloak) | 0.6.0 |
+| https://goodrxoss.github.io/helm-charts | keycloak(lifecycle-keycloak) | 0.7.0 |
 | https://goodrxoss.github.io/helm-charts | ui(lifecycle-ui) | 0.3.0 |
 | https://jouve.github.io/charts | distribution(distribution) | 0.1.7 |
 
@@ -171,6 +171,13 @@ helm upgrade -i lifecycle \
 | distribution.ingress.ingressClassName | string | `"nginx"` |  |
 | distribution.persistence.enabled | bool | `true` |  |
 | distribution.persistence.size | string | `"20Gi"` |  |
+| externalDatabase.database | string | `"lifecycle"` |  |
+| externalDatabase.enabled | bool | `false` |  |
+| externalDatabase.host | string | `nil` |  |
+| externalDatabase.password.secretKeyRef.key | string | `nil` |  |
+| externalDatabase.password.secretKeyRef.name | string | `nil` |  |
+| externalDatabase.port | int | `5432` |  |
+| externalDatabase.username | string | `"lifecycle"` |  |
 | global.appSubDomain | string | `"app"` |  |
 | global.domain | string | `"example.com"` |  |
 | global.envFrom | object | `{}` |  |
@@ -201,12 +208,22 @@ helm upgrade -i lifecycle \
 | global.serviceAccount.name | string | `""` |  |
 | keycloak.clients.lifecycleUi.url | string | `"https://ui.example.com"` |  |
 | keycloak.enabled | bool | `true` |  |
+| keycloak.externalDatabase.database | string | `"keycloak"` |  |
+| keycloak.externalDatabase.enabled | bool | `false` |  |
+| keycloak.externalDatabase.host | string | `nil` |  |
+| keycloak.externalDatabase.password.secretKeyRef.key | string | `nil` |  |
+| keycloak.externalDatabase.password.secretKeyRef.name | string | `nil` |  |
+| keycloak.externalDatabase.port | int | `5432` |  |
+| keycloak.externalDatabase.username | string | `"keycloak"` |  |
+| keycloak.externalDatabase.vendor | string | `"postgres"` |  |
 | keycloak.githubIdp.clientId.secretKeyRef.key | string | `"GITHUB_CLIENT_ID"` |  |
 | keycloak.githubIdp.clientId.secretKeyRef.name | string | `"{{ include \"lifecycle-keycloak.parentChartPrefix\" . }}-bootstrap"` |  |
 | keycloak.githubIdp.clientSecret.secretKeyRef.key | string | `"GITHUB_CLIENT_SECRET"` |  |
 | keycloak.githubIdp.clientSecret.secretKeyRef.name | string | `"{{ include \"lifecycle-keycloak.parentChartPrefix\" . }}-bootstrap"` |  |
 | keycloak.hostname | string | `"https://auth.example.com"` |  |
+| keycloak.keycloakPostgres.enabled | bool | `true` |  |
 | keycloak.keycloakPostgres.nameOverride | string | `"keycloak-postgres"` |  |
+| keycloak.secrets.postgres.enabled | bool | `true` |  |
 | postgres.auth.database | string | `"lifecycle"` |  |
 | postgres.auth.existingSecret | string | `"{{ include \"..helper.postgresSecretName\" . }}"` |  |
 | postgres.auth.secretKeys.adminPasswordKey | string | `"POSTGRES_ADMIN_PASSWORD"` |  |

--- a/charts/lifecycle/templates/deployments.yaml
+++ b/charts/lifecycle/templates/deployments.yaml
@@ -108,6 +108,21 @@ spec:
                 value: {{ "postgres" | quote }}
                 {{- end }}
             {{- end }}
+            {{- if $.Values.externalDatabase.enabled }}
+            - name: APP_DB_HOST
+              value: {{ $.Values.externalDatabase.host | quote }}
+            - name: APP_DB_PORT
+              value: {{ $.Values.externalDatabase.port | quote }}
+            - name: APP_DB_USER
+              value: {{ $.Values.externalDatabase.username | quote }}
+            - name: APP_DB_NAME
+              value: {{ $.Values.externalDatabase.database | quote }}
+            - name: APP_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.externalDatabase.password.secretKeyRef.name | quote }}
+                  key: {{ $.Values.externalDatabase.password.secretKeyRef.key | quote }}
+            {{- end }}
             {{- if $.Values.redis.enabled }}
             - name: APP_REDIS_HOST
               value: {{ include "..helper.redisSvcPrefix" $ }}

--- a/charts/lifecycle/values.yaml
+++ b/charts/lifecycle/values.yaml
@@ -195,6 +195,17 @@ components:
               type: Utilization
               averageUtilization: 80
 
+externalDatabase:
+  enabled: false
+  host:
+  port: 5432
+  database: lifecycle
+  username: lifecycle
+  password:
+    secretKeyRef:
+      name:
+      key:
+
 rbac:
   create: true
 
@@ -344,8 +355,25 @@ keycloak:
         name: '{{ include "lifecycle-keycloak.parentChartPrefix" . }}-bootstrap'
         key: GITHUB_CLIENT_SECRET
 
+  secrets:
+    postgres:
+      enabled: true
+
   keycloakPostgres:
+    enabled: true
     nameOverride: keycloak-postgres
+
+  externalDatabase:
+    enabled: false
+    vendor: postgres
+    host:
+    port: 5432
+    database: keycloak
+    username: keycloak
+    password:
+      secretKeyRef:
+        name:
+        key:
 
 ui:
   enabled: true


### PR DESCRIPTION
## 📝 Description

This PR introduces the ability to use an external database (PostgreSQL) for both `lifecycle` and `keycloak` components. Previously, the system relied solely on internal database containers.

With these changes, users can now connect to managed database services (e.g., AWS RDS, Azure Database for PostgreSQL, Cloud SQL) or existing standalone database instances by configuring the `externalDatabase` block in `values.yaml`.

## 🚀 Key Changes

### 1. External Database Integration

Updated the deployment templates to inject database connection parameters via environment variables when an external DB is enabled:

* **Connectivity**: Support for custom `host`, `port`, and `database` name.
* **Secure Authentication**: Integrated `secretKeyRef` support for `APP_DB_PASSWORD`, allowing passwords to be sourced from existing Kubernetes Secrets rather than plain text.
* **Environment Variables**: New variables injected into the containers: `APP_DB_HOST`, `APP_DB_PORT`, `APP_DB_USER`, `APP_DB_NAME`, and `APP_DB_PASSWORD`.

### 2. Configuration Schema (`values.yaml`)

Added standardized configuration blocks (disabled by default):

* `externalDatabase.enabled`: Toggle to switch between internal and external DB logic.
* Defined default schemas for `lifecycle` and `keycloak` including `host`, `port`, `database`, `username`, and `password.secretKeyRef` structures.

### 3. Versioning

* Bumped the main `lifecycle` chart version from **0.6.0** to **0.7.0**.
* Updated the `lifecycle-keycloak` dependency alias to version **0.7.0**.

## 🛠 Configuration Example

To enable an external database, update your `values.yaml` as follows:

```yaml
externalDatabase:
  enabled: true
  host: "postgres.external.domain"
  port: 5432
  database: "app_db"
  username: "db_admin"
  password:
    secretKeyRef:
      name: "my-db-secret"
      key: "postgres-password"

```

## ✅ Checklist

* [x] External DB logic implemented in `lifecycle` templates.
* [x] External DB logic implemented in `keycloak` sub-chart configuration.
* [x] Verified `secretKeyRef` mapping for sensitive credentials.
* [x] Performed version bump for parent and child charts (v0.7.0).
* [x] Default values added to `values.yaml` for clear documentation.