### PR TITLE
fix: set buildkit terminationGracePeriodSeconds to 3600

### DIFF
--- a/charts/lifecycle/README.md
+++ b/charts/lifecycle/README.md
@@ -67,6 +67,7 @@ helm upgrade -i lifecycle \
 | buildkit.fullnameOverride | string | `""` |  |
 | buildkit.resources.requests.cpu | string | `"500m"` |  |
 | buildkit.resources.requests.memory | string | `"1Gi"` |  |
+| buildkit.terminationGracePeriodSeconds | int | `3600` |  |
 | components.web.container.args | list | `[]` |  |
 | components.web.container.command | list | `[]` |  |
 | components.web.deployment.affinity | object | `{}` |  |

--- a/charts/lifecycle/values.yaml
+++ b/charts/lifecycle/values.yaml
@@ -328,6 +328,7 @@ distribution:
 
 buildkit:
   enabled: true
+  terminationGracePeriodSeconds: 3600
   fullnameOverride: ""
   buildkitdToml: |
     debug = true


### PR DESCRIPTION
## Problem

The default Kubernetes `terminationGracePeriodSeconds` is 30 seconds. When the `buildkitd` pod is evicted or restarted during an active build, Kubernetes sends SIGTERM and then force-kills the pod after only 30 seconds. This tears down the gRPC connection mid-build, causing **gRPC GOAWAY errors** on the Lifecycle build client.

These errors are non-deterministic and surface as transient build failures — frustrating for engineers since retrying the build usually succeeds, masking the root cause.

## Fix

Added `terminationGracePeriodSeconds: 3600` to the `buildkit:` section of `charts/lifecycle/values.yaml`.

This gives active builds up to **1 hour** to complete before the pod is force-terminated, eliminating GOAWAY errors during routine pod lifecycle events (node drain, pod eviction, rolling restarts, etc.).

## Changes

- `charts/lifecycle/values.yaml` — added `terminationGracePeriodSeconds: 3600` under `buildkit:`

## Testing

- No logic change; this is a Helm values override.
- Verify by draining a node while a long-running build is active — the build should complete without gRPC GOAWAY errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)