### PR TITLE
Bump buildkit-service chart to 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ A collection of Helm charts primarily used for **Lifecycle** application deploym
 | Chart | Version | App Version | Description |
 | :--- | :--- | :--- | :--- |
 | [keycloak-operator](./charts/keycloak-operator) | `0.1.0` | `26.4.7` | Helm chart for Keycloak operator based on the [official manifests](https://www.keycloak.org/operator/installation#_installing_by_using_kubectl_without_operator_lifecycle_manager) |
-| [lifecycle](./charts/lifecycle) | `0.9.0` | `0.1.11` | A Helm umbrella chart for full Lifecycle stack |
+| [lifecycle](./charts/lifecycle) | `0.9.1` | `0.1.11` | A Helm umbrella chart for full Lifecycle stack |
 | [lifecycle-keycloak](./charts/lifecycle-keycloak) | `0.7.0` | `0.0.0` | Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports |
 | [lifecycle-ui](./charts/lifecycle-ui) | `0.3.0` | `0.1.2` | A Helm chart for Lifecycle UI (Next.js) |

--- a/charts/lifecycle/Chart.yaml
+++ b/charts/lifecycle/Chart.yaml
@@ -44,7 +44,7 @@ dependencies:
   # BuildKit (Buildx) Dependency
   - name: buildkit-service
     alias: buildkit
-    version: 0.10.0
+    version: 1.4.0
     repository: "https://andrcuns.github.io/charts"
     condition: buildkit.enabled
 

--- a/charts/lifecycle/Chart.yaml
+++ b/charts/lifecycle/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: lifecycle
 description: A Helm umbrella chart for full Lifecycle stack
 type: application
-version: 0.9.0
+version: 0.9.1
 appVersion: 0.1.11
 
 dependencies:

--- a/charts/lifecycle/README.md
+++ b/charts/lifecycle/README.md
@@ -1,6 +1,6 @@
 # lifecycle
 
-![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.1.11](https://img.shields.io/badge/AppVersion-0.1.11-informational?style=flat-square)
+![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.1.11](https://img.shields.io/badge/AppVersion-0.1.11-informational?style=flat-square)
 
 A Helm umbrella chart for full Lifecycle stack
 
@@ -40,7 +40,7 @@ buildkit:
 ```bash
 helm upgrade -i lifecycle \
   oci://ghcr.io/goodrxoss/helm-charts/lifecycle \
-  --version 0.9.0 \
+  --version 0.9.1 \
   -f values.yaml \
   -n lifecycle-app \
   --create-namespace

--- a/charts/lifecycle/README.md
+++ b/charts/lifecycle/README.md
@@ -50,7 +50,7 @@ helm upgrade -i lifecycle \
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://andrcuns.github.io/charts | buildkit(buildkit-service) | 0.10.0 |
+| https://andrcuns.github.io/charts | buildkit(buildkit-service) | 1.4.0 |
 | https://charts.bitnami.com/bitnami | minio(minio) | 17.0.21 |
 | https://charts.bitnami.com/bitnami | postgres(postgresql) | 15.5.19 |
 | https://charts.bitnami.com/bitnami | redis(redis) | 19.6.3 |


### PR DESCRIPTION
## Summary
- bump the lifecycle chart buildkit-service dependency from 0.10.0 to 1.4.0
- regenerate the lifecycle chart README via the repo's helm-docs pre-commit hook

## Verification
- pre-commit run --files charts/lifecycle/Chart.yaml charts/lifecycle/README.md