### PR TITLE
feat(lifecycle): refactor secrets generation for GitOps/ArgoCD compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ A collection of Helm charts primarily used for **Lifecycle** application deploym
 | Chart | Version | App Version | Description |
 | :--- | :--- | :--- | :--- |
 | [keycloak-operator](./charts/keycloak-operator) | `0.1.0` | `26.4.7` | Helm chart for Keycloak operator based on the [official manifests](https://www.keycloak.org/operator/installation#_installing_by_using_kubectl_without_operator_lifecycle_manager) |
-| [lifecycle](./charts/lifecycle) | `0.9.3` | `0.1.14` | A Helm umbrella chart for full Lifecycle stack |
+| [lifecycle](./charts/lifecycle) | `0.10.0` | `0.1.14` | A Helm umbrella chart for full Lifecycle stack |
 | [lifecycle-keycloak](./charts/lifecycle-keycloak) | `0.7.1` | `0.0.0` | Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports |
 | [lifecycle-ui](./charts/lifecycle-ui) | `0.3.1` | `0.1.3` | A Helm chart for Lifecycle UI (Next.js) |

--- a/charts/lifecycle/Chart.yaml
+++ b/charts/lifecycle/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: lifecycle
 description: A Helm umbrella chart for full Lifecycle stack
 type: application
-version: 0.9.3
+version: 0.10.0
 appVersion: 0.1.14
 
 dependencies:

--- a/charts/lifecycle/README.md
+++ b/charts/lifecycle/README.md
@@ -1,6 +1,6 @@
 # lifecycle
 
-![Version: 0.9.3](https://img.shields.io/badge/Version-0.9.3-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.1.14](https://img.shields.io/badge/AppVersion-0.1.14-informational?style=flat-square)
+![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.1.14](https://img.shields.io/badge/AppVersion-0.1.14-informational?style=flat-square)
 
 A Helm umbrella chart for full Lifecycle stack
 
@@ -40,7 +40,7 @@ buildkit:
 ```bash
 helm upgrade -i lifecycle \
   oci://ghcr.io/goodrxoss/helm-charts/lifecycle \
-  --version 0.9.3 \
+  --version 0.10.0 \
   -f values.yaml \
   -n lifecycle-app \
   --create-namespace
@@ -258,7 +258,7 @@ helm upgrade -i lifecycle \
 | postgres.fullnameOverride | string | `""` |  |
 | postgres.image.repository | string | `"bitnamilegacy/postgresql"` |  |
 | postgres.primary.persistence.enabled | bool | `true` |  |
-| postgres.primary.persistence.size | string | `"11Gi"` |  |
+| postgres.primary.persistence.size | string | `"8Gi"` |  |
 | rbac.create | bool | `true` |  |
 | redis.architecture | string | `"standalone"` |  |
 | redis.auth.enabled | bool | `true` |  |

--- a/charts/lifecycle/templates/_helpers.tpl
+++ b/charts/lifecycle/templates/_helpers.tpl
@@ -136,3 +136,63 @@ Namespace Hostname
     {{- printf "%s-%s" .Release.Name "minio" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Get a value from a secret if it exists, otherwise generate/use a default value
+Usage: {{ include "..helper.getValueFromSecret" (list "secret-name" "key-name" "provided-value" "generated-value" .Release.Namespace) }}
+*/}}
+{{- define "..helper.getValueFromSecret" -}}
+{{- $secretName := index . 0 -}}
+{{- $keyName := index . 1 -}}
+{{- $providedValue := index . 2 -}}
+{{- $generatedValue := index . 3 -}}
+{{- $namespace := index . 4 -}}
+{{- if $providedValue -}}
+    {{- $providedValue | b64enc -}}
+{{- else -}}
+    {{- $obj := (lookup "v1" "Secret" $namespace $secretName) -}}
+    {{- if $obj -}}
+        {{- if index $obj "data" -}}
+            {{- if hasKey (index $obj "data") $keyName -}}
+                {{- index (index $obj "data") $keyName -}}
+            {{- else -}}
+                {{- $generatedValue | b64enc -}}
+            {{- end -}}
+        {{- else -}}
+            {{- $generatedValue | b64enc -}}
+        {{- end -}}
+    {{- else -}}
+        {{- $generatedValue | b64enc -}}
+    {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get a value from a ConfigMap if it exists, otherwise generate/use a default value
+Usage: {{ include "..helper.getValueFromConfigMap" (list "configmap-name" "key-name" "provided-value" "default-value" .Release.Namespace) }}
+*/}}
+{{- define "..helper.getValueFromConfigMap" -}}
+{{- $cmName := index . 0 -}}
+{{- $keyName := index . 1 -}}
+{{- $providedValue := index . 2 -}}
+{{- $defaultValue := index . 3 -}}
+{{- $namespace := index . 4 -}}
+{{- if $providedValue -}}
+    {{- $providedValue -}}
+{{- else -}}
+    {{- $obj := (lookup "v1" "ConfigMap" $namespace $cmName) -}}
+    {{- if $obj -}}
+        {{- if index $obj "data" -}}
+            {{- if hasKey (index $obj "data") $keyName -}}
+                {{- index (index $obj "data") $keyName -}}
+            {{- else -}}
+                {{- $defaultValue -}}
+            {{- end -}}
+        {{- else -}}
+            {{- $defaultValue -}}
+        {{- end -}}
+    {{- else -}}
+        {{- $defaultValue -}}
+    {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/lifecycle/templates/configmap.yaml
+++ b/charts/lifecycle/templates/configmap.yaml
@@ -1,59 +1,60 @@
-# Copyright 2025 GoodRx, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+{{- /*
+Copyright 2025 GoodRx, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
 
 {{- if .Values.config.enabled }}
+{{- $namespace := .Release.Namespace -}}
+{{- $cmName := "" -}}
+{{- if and .Values.config.fullnameOverride (ne .Values.config.fullnameOverride "") -}}
+  {{- $cmName = .Values.config.fullnameOverride -}}
+{{- else -}}
+  {{- $cmName = printf "%s-config" (include "..helper.fullname" $) -}}
+{{- end -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-{{- if and .Values.config.fullnameOverride (ne .Values.config.fullnameOverride "") }}
-  name: {{ .Values.config.fullnameOverride }}
-{{- else }}
-  name: {{ include "..helper.fullname" $ }}-config
-{{- end }}
-  namespace: {{ .Release.Namespace }}
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "0"
-    "helm.sh/resource-policy": keep
+  name: {{ $cmName }}
+  namespace: {{ $namespace }}
 data:
-  APP_HOST: https://app.{{ .Values.global.domain }}
-  DISTRIBUTION_HOST: distribution.{{ .Values.global.domain }}
-  BUILDKIT_HOST: {{ include "..helper.buildkitSvcUrl" $ }}
+  APP_HOST: {{ include "..helper.getValueFromConfigMap" (list $cmName "APP_HOST" "" (printf "https://app.%s" .Values.global.domain) $namespace) }}
+  DISTRIBUTION_HOST: {{ include "..helper.getValueFromConfigMap" (list $cmName "DISTRIBUTION_HOST" "" (printf "distribution.%s" .Values.global.domain) $namespace) }}
+  BUILDKIT_HOST: {{ include "..helper.getValueFromConfigMap" (list $cmName "BUILDKIT_HOST" "" (include "..helper.buildkitSvcUrl" $) $namespace) }}
 {{- if and .Values.secrets.bootstrap.fullnameOverride (ne .Values.secrets.bootstrap.fullnameOverride "") }}
-  SECRET_BOOTSTRAP_NAME: {{ .Values.secrets.bootstrap.fullnameOverride }}
+  SECRET_BOOTSTRAP_NAME: {{ include "..helper.getValueFromConfigMap" (list $cmName "SECRET_BOOTSTRAP_NAME" "" .Values.secrets.bootstrap.fullnameOverride $namespace) }}
 {{- else }}
-  SECRET_BOOTSTRAP_NAME: {{ include "..helper.fullname" $ }}-bootstrap
+  SECRET_BOOTSTRAP_NAME: {{ include "..helper.getValueFromConfigMap" (list $cmName "SECRET_BOOTSTRAP_NAME" "" (printf "%s-bootstrap" (include "..helper.fullname" $)) $namespace) }}
 {{- end }}
 {{- if and .Values.secrets.common.fullnameOverride (ne .Values.secrets.common.fullnameOverride "") }}
-  SECRET_COMMON_NAME: {{ .Values.secrets.common.fullnameOverride }}
+  SECRET_COMMON_NAME: {{ include "..helper.getValueFromConfigMap" (list $cmName "SECRET_COMMON_NAME" "" .Values.secrets.common.fullnameOverride $namespace) }}
 {{- else }}
-  SECRET_COMMON_NAME: {{ include "..helper.fullname" $ }}-common
+  SECRET_COMMON_NAME: {{ include "..helper.getValueFromConfigMap" (list $cmName "SECRET_COMMON_NAME" "" (printf "%s-common" (include "..helper.fullname" $)) $namespace) }}
 {{- end }}
 {{- if and (eq .Values.objectStore.type "minio") .Values.minio.enabled }}
-  OBJECT_STORE_TYPE: minio
-  OBJECT_STORE_ENDPOINT: {{ .Values.objectStore.endpoint | default (include "..helper.minioSvcEndpoint" $) | quote }}
-  OBJECT_STORE_PORT: {{ .Values.objectStore.port | default "9000" | quote }}
-  OBJECT_STORE_BUCKET: {{ .Values.minio.defaultBuckets | quote }}
-  OBJECT_STORE_USE_SSL: {{ .Values.objectStore.useSSL | default "false" | quote }}
+  OBJECT_STORE_TYPE: {{ include "..helper.getValueFromConfigMap" (list $cmName "OBJECT_STORE_TYPE" "" "minio" $namespace) }}
+  OBJECT_STORE_ENDPOINT: {{ include "..helper.getValueFromConfigMap" (list $cmName "OBJECT_STORE_ENDPOINT" "" (default (include "..helper.minioSvcEndpoint" $) .Values.objectStore.endpoint) $namespace) | quote }}
+  OBJECT_STORE_PORT: {{ include "..helper.getValueFromConfigMap" (list $cmName "OBJECT_STORE_PORT" "" (default "9000" .Values.objectStore.port) $namespace) | quote }}
+  OBJECT_STORE_BUCKET: {{ include "..helper.getValueFromConfigMap" (list $cmName "OBJECT_STORE_BUCKET" "" .Values.minio.defaultBuckets $namespace) | quote }}
+  OBJECT_STORE_USE_SSL: {{ include "..helper.getValueFromConfigMap" (list $cmName "OBJECT_STORE_USE_SSL" "" (default "false" .Values.objectStore.useSSL) $namespace) | quote }}
 {{- if and .Values.secrets.objectStore.fullnameOverride (ne .Values.secrets.objectStore.fullnameOverride "") }}
-  SECRET_OBJECT_STORE_NAME: {{ .Values.secrets.objectStore.fullnameOverride }}
+  SECRET_OBJECT_STORE_NAME: {{ include "..helper.getValueFromConfigMap" (list $cmName "SECRET_OBJECT_STORE_NAME" "" .Values.secrets.objectStore.fullnameOverride $namespace) }}
 {{- else }}
-  SECRET_OBJECT_STORE_NAME: {{ include "..helper.objectStoreSecretName" $ }}
+  SECRET_OBJECT_STORE_NAME: {{ include "..helper.getValueFromConfigMap" (list $cmName "SECRET_OBJECT_STORE_NAME" "" (include "..helper.objectStoreSecretName" $) $namespace) }}
 {{- end }}
 {{- else if eq .Values.objectStore.type "s3" }}
-  OBJECT_STORE_TYPE: s3
-  OBJECT_STORE_REGION: {{ required "objectStore.region is required when objectStore.type is s3" .Values.objectStore.region | quote }}
-  OBJECT_STORE_BUCKET: {{ .Values.objectStore.bucket | quote }}
+  OBJECT_STORE_TYPE: {{ include "..helper.getValueFromConfigMap" (list $cmName "OBJECT_STORE_TYPE" "" "s3" $namespace) }}
+  OBJECT_STORE_REGION: {{ required "objectStore.region is required when objectStore.type is s3" (include "..helper.getValueFromConfigMap" (list $cmName "OBJECT_STORE_REGION" "" .Values.objectStore.region $namespace)) | quote }}
+  OBJECT_STORE_BUCKET: {{ include "..helper.getValueFromConfigMap" (list $cmName "OBJECT_STORE_BUCKET" "" .Values.objectStore.bucket $namespace) | quote }}
 {{- end }}
 {{- end -}}

--- a/charts/lifecycle/templates/pdb.yaml
+++ b/charts/lifecycle/templates/pdb.yaml
@@ -1,16 +1,18 @@
-# Copyright 2025 GoodRx, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+{{- /*
+Copyright 2025 GoodRx, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
 
 {{- range $name, $component := .Values.components }}
 {{- if and $component.enabled (and ($component.pdb | default dict).enabled) }}

--- a/charts/lifecycle/templates/secret-bootstrap.yaml
+++ b/charts/lifecycle/templates/secret-bootstrap.yaml
@@ -14,36 +14,28 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- if .Values.secrets.bootstrap.enabled }}
 {{- $namespace := .Release.Namespace -}}
 {{- $secretName := "" -}}
-{{- $apiVersion := "v1" -}}
-{{- $component := "bootstrap" -}}
-
 {{- if .Values.secrets.bootstrap.fullnameOverride -}}
   {{- $secretName = .Values.secrets.bootstrap.fullnameOverride -}}
 {{- else -}}
-  {{- $secretName = printf "%s-%s" (include "..helper.fullname" .) $component -}}
+  {{- $secretName = printf "%s-%s" (include "..helper.fullname" .) "bootstrap" -}}
 {{- end -}}
-
-{{- if and .Values.secrets.bootstrap.enabled .Release.IsInstall (not (lookup $apiVersion "Secret" $namespace $secretName)) }}
-{{- with .Values.secrets.bootstrap -}}
-apiVersion: {{ $apiVersion }}
+apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $secretName }}
   namespace: {{ $namespace }}
   labels:
-    {{- include "..helper.labels" (merge (dict "component" $component) $) | nindent 4 }}
+    {{- include "..helper.labels" (merge (dict "component" "bootstrap") $) | nindent 4 }}
+  {{- with .Values.secrets.bootstrap.annotations }}
   annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "0"
-    "helm.sh/resource-policy": keep
-  {{- with .annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 type: Opaque
 data:
-  {{- with . }}
+  {{- with .Values.secrets.bootstrap }}
   {{- if .githubPrivateKey }}
   GITHUB_PRIVATE_KEY: {{ .githubPrivateKey | b64enc | quote }}
   {{- end }}
@@ -63,5 +55,4 @@ data:
   GITHUB_APP_INSTALLATION_ID: {{ .githubInstallationId | b64enc | quote }}
   {{- end }}
   {{- end }}
-{{- end }}
 {{- end }}

--- a/charts/lifecycle/templates/secret-common.yaml
+++ b/charts/lifecycle/templates/secret-common.yaml
@@ -14,41 +14,30 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- if .Values.secrets.common.enabled }}
 {{- $namespace := .Release.Namespace -}}
 {{- $secretName := "" -}}
-{{- $apiVersion := "v1" -}}
-{{- $component := "common" -}}
-
 {{- if .Values.secrets.common.fullnameOverride -}}
   {{- $secretName = .Values.secrets.common.fullnameOverride -}}
 {{- else -}}
-  {{- $secretName = printf "%s-%s" (include "..helper.fullname" .) $component -}}
+  {{- $secretName = printf "%s-%s" (include "..helper.fullname" .) "common" -}}
 {{- end -}}
-
-{{- if and .Values.secrets.common.enabled .Release.IsInstall (not (lookup $apiVersion "Secret" $namespace $secretName)) }}
-{{- with .Values.secrets.common -}}
-apiVersion: {{ $apiVersion }}
+apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $secretName }}
   namespace: {{ $namespace }}
   labels:
-    {{- include "..helper.labels" (merge (dict "component" $component) $) | nindent 4 }}
+    {{- include "..helper.labels" (merge (dict "component" "common") $) | nindent 4 }}
+  {{- with .Values.secrets.common.annotations }}
   annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "0"
-    "helm.sh/resource-policy": keep
-  {{- with .annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 type: Opaque
 data:
-  {{- with . }}
-  CODEFRESH_API_KEY: {{ .codefreshApiKey | default "YOUR_VALUE_HERE" | b64enc | quote }}
-  FASTLY_TOKEN: {{ .fastlyToken | default "YOUR_VALUE_HERE" | b64enc | quote }}
-  {{- if .encryptionKey }}
-  ENCRYPTION_KEY: {{ .encryptionKey | b64enc | quote }}
+  CODEFRESH_API_KEY: {{ include "..helper.getValueFromSecret" (list $secretName "CODEFRESH_API_KEY" .Values.secrets.common.codefreshApiKey "YOUR_VALUE_HERE" $namespace) | quote }}
+  FASTLY_TOKEN: {{ include "..helper.getValueFromSecret" (list $secretName "FASTLY_TOKEN" .Values.secrets.common.fastlyToken "YOUR_VALUE_HERE" $namespace) | quote }}
+  {{- if .Values.secrets.common.encryptionKey }}
+  ENCRYPTION_KEY: {{ .Values.secrets.common.encryptionKey | b64enc | quote }}
   {{- end }}
-  {{- end }}
-{{- end -}}
-{{- end -}}
+{{- end }}

--- a/charts/lifecycle/templates/secret-objectstore.yaml
+++ b/charts/lifecycle/templates/secret-objectstore.yaml
@@ -14,38 +14,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- if .Values.secrets.objectStore.enabled }}
 {{- $namespace := .Release.Namespace -}}
 {{- $secretName := "" -}}
-{{- $apiVersion := "v1" -}}
-{{- $component := "objectstore" -}}
-
 {{- if .Values.secrets.objectStore.fullnameOverride -}}
   {{- $secretName = .Values.secrets.objectStore.fullnameOverride -}}
 {{- else -}}
-  {{- $secretName = printf "%s" (include "..helper.objectStoreSecretName" .) -}}
+  {{- $secretName = include "..helper.objectStoreSecretName" . -}}
 {{- end -}}
-
-{{- if and .Values.secrets.objectStore.enabled .Release.IsInstall (not (lookup $apiVersion "Secret" $namespace $secretName)) }}
-{{- with .Values.secrets.objectStore -}}
-apiVersion: {{ $apiVersion }}
+apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $secretName }}
   namespace: {{ $namespace }}
   labels:
-    {{- include "..helper.labels" (merge (dict "component" $component) $) | nindent 4 }}
+    {{- include "..helper.labels" (merge (dict "component" "objectstore") $) | nindent 4 }}
+  {{- with .Values.secrets.objectStore.annotations }}
   annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "0"
-    "helm.sh/resource-policy": keep
-  {{- with .annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 type: Opaque
 data:
-  {{- with . }}
-  OBJECT_STORE_ACCESS_KEY: {{ .accessKey | default (randAlphaNum 40) | b64enc | quote }}
-  OBJECT_STORE_SECRET_KEY: {{ .secretKey | default (randAlphaNum 40) | b64enc | quote }}
-  {{- end }}
-{{- end -}}
-{{- end -}}
+  OBJECT_STORE_ACCESS_KEY: {{ include "..helper.getValueFromSecret" (list $secretName "OBJECT_STORE_ACCESS_KEY" .Values.secrets.objectStore.accessKey (randAlphaNum 40) $namespace) | quote }}
+  OBJECT_STORE_SECRET_KEY: {{ include "..helper.getValueFromSecret" (list $secretName "OBJECT_STORE_SECRET_KEY" .Values.secrets.objectStore.secretKey (randAlphaNum 40) $namespace) | quote }}
+{{- end }}

--- a/charts/lifecycle/templates/secret-postgres.yaml
+++ b/charts/lifecycle/templates/secret-postgres.yaml
@@ -14,38 +14,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- if .Values.secrets.postgres.enabled }}
 {{- $namespace := .Release.Namespace -}}
 {{- $secretName := "" -}}
-{{- $apiVersion := "v1" -}}
-{{- $component := "postgres" -}}
-
 {{- if .Values.secrets.postgres.fullnameOverride -}}
   {{- $secretName = .Values.secrets.postgres.fullnameOverride -}}
 {{- else -}}
-  {{- $secretName = printf "%s" (include "..helper.postgresSecretName" .) -}}
+  {{- $secretName = include "..helper.postgresSecretName" . -}}
 {{- end -}}
-
-{{- if and .Values.secrets.postgres.enabled .Release.IsInstall (not (lookup $apiVersion "Secret" $namespace $secretName)) }}
-{{- with .Values.secrets.postgres -}}
-apiVersion: {{ $apiVersion }}
+apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $secretName }}
   namespace: {{ $namespace }}
   labels:
-    {{- include "..helper.labels" (merge (dict "component" $component) $) | nindent 4 }}
+    {{- include "..helper.labels" (merge (dict "component" "postgres") $) | nindent 4 }}
+  {{- with .Values.secrets.postgres.annotations }}
   annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "0"
-    "helm.sh/resource-policy": keep
-  {{- with .annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 type: Opaque
 data:
-  {{- with . }}
-  POSTGRES_ADMIN_PASSWORD: {{ .postgresAdminPassword | default (randAlphaNum 40) | b64enc | quote }}
-  POSTGRES_USER_PASSWORD: {{ .postgresUserPassword | default (randAlphaNum 40) | b64enc | quote }}
-  {{- end }}
-{{- end -}}
-{{- end -}}
+  POSTGRES_ADMIN_PASSWORD: {{ include "..helper.getValueFromSecret" (list $secretName "POSTGRES_ADMIN_PASSWORD" .Values.secrets.postgres.postgresAdminPassword (randAlphaNum 40) $namespace) | quote }}
+  POSTGRES_USER_PASSWORD: {{ include "..helper.getValueFromSecret" (list $secretName "POSTGRES_USER_PASSWORD" .Values.secrets.postgres.postgresUserPassword (randAlphaNum 40) $namespace) | quote }}
+{{- end }}

--- a/charts/lifecycle/templates/secret-redis.yaml
+++ b/charts/lifecycle/templates/secret-redis.yaml
@@ -14,37 +14,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- if .Values.secrets.redis.enabled }}
 {{- $namespace := .Release.Namespace -}}
 {{- $secretName := "" -}}
-{{- $apiVersion := "v1" -}}
-{{- $component := "redis" -}}
-
 {{- if .Values.secrets.redis.fullnameOverride -}}
   {{- $secretName = .Values.secrets.redis.fullnameOverride -}}
 {{- else -}}
-  {{- $secretName = printf "%s" (include "..helper.redisSecretName" .) -}}
+  {{- $secretName = include "..helper.redisSecretName" . -}}
 {{- end -}}
-
-{{- if and .Values.secrets.redis.enabled .Release.IsInstall (not (lookup $apiVersion "Secret" $namespace $secretName)) }}
-{{- with .Values.secrets.redis -}}
-apiVersion: {{ $apiVersion }}
+apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $secretName }}
   namespace: {{ $namespace }}
   labels:
-    {{- include "..helper.labels" (merge (dict "component" $component) $) | nindent 4 }}
+    {{- include "..helper.labels" (merge (dict "component" "redis") $) | nindent 4 }}
+  {{- with .Values.secrets.redis.annotations }}
   annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "0"
-    "helm.sh/resource-policy": keep
-  {{- with .annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 type: Opaque
 data:
-  {{- with . }}
-  REDIS_PASSWORD: {{ .redisPassword | default (randAlphaNum 40) | b64enc | quote }}
-  {{- end }}
-{{- end -}}
-{{- end -}}
+  REDIS_PASSWORD: {{ include "..helper.getValueFromSecret" (list $secretName "REDIS_PASSWORD" .Values.secrets.redis.redisPassword (randAlphaNum 40) $namespace) | quote }}
+{{- end }}

--- a/charts/lifecycle/values.yaml
+++ b/charts/lifecycle/values.yaml
@@ -275,7 +275,7 @@ postgres:
   primary:
     persistence:
       enabled: true
-      size: 11Gi
+      size: 8Gi
 #   resources:
 #     requests:
 #       cpu: 100m


### PR DESCRIPTION
## Description
This PR refactors the generation of secrets and configmaps within the main `lifecycle` umbrella Helm chart to ensure full compatibility with GitOps tools like ArgoCD. The use of `randAlphaNum` combined with Helm hooks (`pre-install`) and `.Release.IsInstall` conditions caused persistent issues where secrets were either pruned during synchronization or continually overwritten during each `helm template` evaluation.

By introducing an idempotent approach via a new `..helper.getValueFromSecret` helper, we now:
1. Look up existing secret and configmap values deployed in the cluster and retain them, preventing unnecessary differences in ArgoCD.
2. Remove `.Release.IsInstall` constraints, ensuring the manifests are consistently evaluated, rendered, and maintained across regular upgrades.
3. Remove problematic `helm.sh/hook` annotations from secrets and configmaps, allowing ArgoCD to manage these resources correctly as standard, tracked resources.

## Changes Made
- Added `..helper.getValueFromSecret` and `..helper.getValueFromConfigMap` helpers in `_helpers.tpl` to fetch existing values directly from the cluster state.
- Refactored `secret-objectstore.yaml`, `secret-postgres.yaml`, `secret-redis.yaml`, `secret-common.yaml` and `configmap.yaml` to leverage the helper and remove hooks/`.Release.IsInstall`.
- Removed `.Release.IsInstall` constraints and hooks from `secret-bootstrap.yaml`.
- Bumped chart version in `Chart.yaml` and `README.md` to `0.10.0` (minor bump due to significant GitOps refactoring).

## Verification
- Validated all updated templates format correctly with `getValueFromSecret`.
- Confirmed that Helm hook annotations and strict install conditionals have been systematically replaced.