### PR TITLE
feat(lifecycle-keycloak): refactor and unify db auth and support templateable secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ A collection of Helm charts primarily used for **Lifecycle** application deploym
 | :--- | :--- | :--- | :--- |
 | [keycloak-operator](./charts/keycloak-operator) | `0.1.0` | `26.4.7` | Helm chart for Keycloak operator based on the [official manifests](https://www.keycloak.org/operator/installation#_installing_by_using_kubectl_without_operator_lifecycle_manager) |
 | [lifecycle](./charts/lifecycle) | `0.9.5` | `0.1.15` | A Helm umbrella chart for full Lifecycle stack |
-| [lifecycle-keycloak](./charts/lifecycle-keycloak) | `0.7.2` | `0.0.0` | Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports |
+| [lifecycle-keycloak](./charts/lifecycle-keycloak) | `0.7.3` | `0.0.0` | Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports |
 | [lifecycle-ui](./charts/lifecycle-ui) | `0.3.2` | `0.1.4` | A Helm chart for Lifecycle UI (Next.js) |

--- a/charts/lifecycle-keycloak/Chart.yaml
+++ b/charts/lifecycle-keycloak/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: lifecycle-keycloak
 description: Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports
 type: application
-version: 0.7.2
+version: 0.7.3
 appVersion: 0.0.0
 home: https://goodrxoss.github.io/helm-charts/charts/lifecycle-keycloak/
 

--- a/charts/lifecycle-keycloak/README.md
+++ b/charts/lifecycle-keycloak/README.md
@@ -1,6 +1,6 @@
 # lifecycle-keycloak
 
-![Version: 0.7.2](https://img.shields.io/badge/Version-0.7.2-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 0.7.3](https://img.shields.io/badge/Version-0.7.3-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports
 
@@ -128,7 +128,7 @@ This chart uses the `KeycloakRealmImport` resource for the initial setup.
 ```shell
 helm upgrade -i lifecycle-keycloak \
   oci://ghcr.io/goodrxoss/helm-charts/lifecycle-keycloak \
-  --version 0.7.2 \
+  --version 0.7.3 \
   -f values.yaml \
   -n lifecycle-keycloak \
   --create-namespace

--- a/charts/lifecycle-keycloak/templates/keycloak-instance.yaml
+++ b/charts/lifecycle-keycloak/templates/keycloak-instance.yaml
@@ -42,12 +42,9 @@ spec:
     host: {{ include "lifecycle-keycloak.postgresSvcPrefix" . | quote }}
     port: 5432
     database: {{ .Values.keycloakPostgres.auth.database | quote }}
-    usernameSecret:
-      name: {{ include "lifecycle-keycloak.postgresSecretName" . | quote }}
-      key: POSTGRES_USERNAME
     passwordSecret:
-      name: {{ include "lifecycle-keycloak.postgresSecretName" . | quote }}
-      key: POSTGRES_USER_PASSWORD
+      name: {{ printf "%s" (tpl .Values.keycloakPostgres.auth.existingSecret $) }}
+      key: {{ .Values.keycloakPostgres.auth.secretKeys.userPasswordKey | quote }}
   {{- end }}
 
   http:
@@ -62,6 +59,9 @@ spec:
   {{- if .Values.externalDatabase.enabled }}
     - name: db-username
       value: {{ .Values.externalDatabase.username | quote }}
+  {{- else }}
+    - name: db-username
+      value: {{ .Values.keycloakPostgres.auth.username | quote }}
   {{- end }}
     - name: hostname-strict-backchannel
       value: "false"

--- a/charts/lifecycle-keycloak/templates/postgres-secret.yaml
+++ b/charts/lifecycle-keycloak/templates/postgres-secret.yaml
@@ -42,8 +42,6 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 type: Opaque
-stringData:
-  POSTGRES_USERNAME: {{ $.Values.keycloakPostgres.auth.username | quote }}
 data:
   {{- with . }}
   POSTGRES_ADMIN_PASSWORD: {{ .adminPassword | default (randAlphaNum 40) | b64enc | quote }}


### PR DESCRIPTION
# Description

## Overview
This PR unifies the database authentication configuration for Keycloak, providing a consistent approach for both internal databases (umbrella chart) and external instances. The focus is on enabling flexible use of external secrets and removing legacy workarounds previously required by the operator.

## Changes
- **`charts/lifecycle-keycloak/templates/keycloak-instance.yaml`**:
    - **Flow Unification**: Introduced the `db-username` environment variable, allowing the database username to be passed consistently for both external and internal databases.
    - **Template Support**: The `existingSecret` field is now processed via `tpl`, enabling dynamic secret name generation.
    - **Key Flexibility**: Removed the hardcoded `POSTGRES_USER_PASSWORD` key. The password key is now retrieved from `.Values.keycloakPostgres.auth.secretKeys.userPasswordKey`, allowing the use of custom keys in existing secrets.
    - **Workaround Removal**: Removed `usernameSecret` as the database username is non-sensitive information and is now handled via environment variables.
- **`charts/lifecycle-keycloak/templates/postgres-secret.yaml`**:
    - Removed `POSTGRES_USERNAME` from `stringData` as this parameter should no longer be stored within a secret.

## Rationale
These changes make the chart more "cloud-native" and easier to integrate into complex infrastructures where database parameters may change dynamically or be provided by external secret management systems (e.g., External Secrets Operator).