### PR TITLE
feat: add lifecycle gateway chart component

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ A collection of Helm charts primarily used for **Lifecycle** application deploym
 | Chart | Version | App Version | Description |
 | :--- | :--- | :--- | :--- |
 | [keycloak-operator](./charts/keycloak-operator) | `0.1.0` | `26.4.7` | Helm chart for Keycloak operator based on the [official manifests](https://www.keycloak.org/operator/installation#_installing_by_using_kubectl_without_operator_lifecycle_manager) |
-| [lifecycle](./charts/lifecycle) | `0.9.6` | `0.1.15` | A Helm umbrella chart for full Lifecycle stack |
+| [lifecycle](./charts/lifecycle) | `0.9.7` | `0.1.15` | A Helm umbrella chart for full Lifecycle stack |
 | [lifecycle-keycloak](./charts/lifecycle-keycloak) | `0.7.3` | `0.0.0` | Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports |
 | [lifecycle-ui](./charts/lifecycle-ui) | `0.3.2` | `0.1.4` | A Helm chart for Lifecycle UI (Next.js) |

--- a/charts/lifecycle/Chart.yaml
+++ b/charts/lifecycle/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: lifecycle
 description: A Helm umbrella chart for full Lifecycle stack
 type: application
-version: 0.9.6
+version: 0.9.7
 appVersion: 0.1.15
 
 dependencies:

--- a/charts/lifecycle/README.md
+++ b/charts/lifecycle/README.md
@@ -1,6 +1,6 @@
 # lifecycle
 
-![Version: 0.9.6](https://img.shields.io/badge/Version-0.9.6-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.1.15](https://img.shields.io/badge/AppVersion-0.1.15-informational?style=flat-square)
+![Version: 0.9.7](https://img.shields.io/badge/Version-0.9.7-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.1.15](https://img.shields.io/badge/AppVersion-0.1.15-informational?style=flat-square)
 
 A Helm umbrella chart for full Lifecycle stack
 
@@ -40,7 +40,7 @@ buildkit:
 ```bash
 helm upgrade -i lifecycle \
   oci://ghcr.io/goodrxoss/helm-charts/lifecycle \
-  --version 0.9.6 \
+  --version 0.9.7 \
   -f values.yaml \
   -n lifecycle-app \
   --create-namespace
@@ -67,6 +67,63 @@ helm upgrade -i lifecycle \
 | buildkit.fullnameOverride | string | `""` |  |
 | buildkit.resources.requests.cpu | string | `"500m"` |  |
 | buildkit.resources.requests.memory | string | `"1Gi"` |  |
+| components.gateway.container.args | list | `[]` |  |
+| components.gateway.container.command | list | `[]` |  |
+| components.gateway.deployment.affinity | object | `{}` |  |
+| components.gateway.deployment.envFrom | object | `{}` |  |
+| components.gateway.deployment.extraEnv[0].name | string | `"LIFECYCLE_MODE"` |  |
+| components.gateway.deployment.extraEnv[0].value | string | `"gateway"` |  |
+| components.gateway.deployment.livenessProbe.failureThreshold | int | `6` |  |
+| components.gateway.deployment.livenessProbe.httpGet.path | string | `"/api/health"` |  |
+| components.gateway.deployment.livenessProbe.httpGet.port | string | `"http"` |  |
+| components.gateway.deployment.livenessProbe.initialDelaySeconds | int | `60` |  |
+| components.gateway.deployment.livenessProbe.periodSeconds | int | `10` |  |
+| components.gateway.deployment.nodeSelector | object | `{}` |  |
+| components.gateway.deployment.ports[0].containerPort | int | `80` |  |
+| components.gateway.deployment.ports[0].name | string | `"http"` |  |
+| components.gateway.deployment.ports[0].protocol | string | `"TCP"` |  |
+| components.gateway.deployment.readinessProbe.failureThreshold | int | `3` |  |
+| components.gateway.deployment.readinessProbe.httpGet.path | string | `"/api/health"` |  |
+| components.gateway.deployment.readinessProbe.httpGet.port | string | `"http"` |  |
+| components.gateway.deployment.readinessProbe.periodSeconds | int | `5` |  |
+| components.gateway.deployment.replicaCount | int | `2` |  |
+| components.gateway.deployment.resources.limits.cpu | string | `"2000m"` |  |
+| components.gateway.deployment.resources.limits.ephemeral-storage | string | `"1Gi"` |  |
+| components.gateway.deployment.resources.limits.memory | string | `"4000Mi"` |  |
+| components.gateway.deployment.resources.requests.cpu | string | `"200m"` |  |
+| components.gateway.deployment.resources.requests.ephemeral-storage | string | `"400Mi"` |  |
+| components.gateway.deployment.resources.requests.memory | string | `"512Mi"` |  |
+| components.gateway.deployment.startupProbe | object | `{}` |  |
+| components.gateway.deployment.tolerations | list | `[]` |  |
+| components.gateway.deployment.volumeMounts | list | `[]` |  |
+| components.gateway.deployment.volumes | list | `[]` |  |
+| components.gateway.enabled | bool | `false` |  |
+| components.gateway.extraLabels | object | `{}` |  |
+| components.gateway.fullnameOverride | string | `""` |  |
+| components.gateway.hpa.enabled | bool | `false` |  |
+| components.gateway.hpa.maxReplicas | int | `10` |  |
+| components.gateway.hpa.metrics[0].resource.name | string | `"cpu"` |  |
+| components.gateway.hpa.metrics[0].resource.target.averageUtilization | int | `80` |  |
+| components.gateway.hpa.metrics[0].resource.target.type | string | `"Utilization"` |  |
+| components.gateway.hpa.metrics[0].type | string | `"Resource"` |  |
+| components.gateway.hpa.minReplicas | int | `2` |  |
+| components.gateway.ingress.annotations | object | `{}` |  |
+| components.gateway.ingress.defaultBackend | object | `{}` |  |
+| components.gateway.ingress.enabled | bool | `false` |  |
+| components.gateway.ingress.hosts[0].host | string | `"*.sites.example.com"` |  |
+| components.gateway.ingress.hosts[0].paths[0] | string | `"/"` |  |
+| components.gateway.ingress.ingressClassName | string | `"nginx"` |  |
+| components.gateway.networkPolicy.egress | list | `[]` |  |
+| components.gateway.networkPolicy.enabled | bool | `false` |  |
+| components.gateway.networkPolicy.ingress | list | `[]` |  |
+| components.gateway.pdb.enabled | bool | `false` |  |
+| components.gateway.pdb.minAvailable | int | `1` |  |
+| components.gateway.service.clusterIP | string | `""` |  |
+| components.gateway.service.enabled | bool | `true` |  |
+| components.gateway.service.externalTrafficPolicy | string | `""` |  |
+| components.gateway.service.port | int | `80` |  |
+| components.gateway.service.targetPort | int | `80` |  |
+| components.gateway.service.type | string | `"ClusterIP"` |  |
 | components.web.container.args | list | `[]` |  |
 | components.web.container.command | list | `[]` |  |
 | components.web.deployment.affinity | object | `{}` |  |

--- a/charts/lifecycle/templates/hpa.yaml
+++ b/charts/lifecycle/templates/hpa.yaml
@@ -32,7 +32,11 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "..helper.fullname" $ }}
+    {{- if and $component.fullnameOverride (ne $component.fullnameOverride "") }}
+    name: {{ $component.fullnameOverride }}
+    {{- else }}
+    name: {{ include "..helper.fullname" $ }}-{{ $name }}
+    {{- end }}
   minReplicas: {{ $component.hpa.minReplicas }}
   maxReplicas: {{ $component.hpa.maxReplicas }}
   metrics:

--- a/charts/lifecycle/templates/networkpolicy.yaml
+++ b/charts/lifecycle/templates/networkpolicy.yaml
@@ -32,6 +32,7 @@ spec:
   podSelector:
     matchLabels:
       {{- include "..helper.selectorLabels" $ | nindent 6 }}
+      app.kubernetes.io/component: {{ $name }}
   policyTypes:
     - Ingress
     - Egress

--- a/charts/lifecycle/templates/pdb.yaml
+++ b/charts/lifecycle/templates/pdb.yaml
@@ -30,6 +30,7 @@ spec:
   selector:
     matchLabels:
       {{- include "..helper.selectorLabels" $ | nindent 6 }}
+      app.kubernetes.io/component: {{ $name }}
   {{- if $component.pdb.minAvailable }}
   minAvailable: {{ $component.pdb.minAvailable }}
   {{- end }}

--- a/charts/lifecycle/values.yaml
+++ b/charts/lifecycle/values.yaml
@@ -195,6 +195,94 @@ components:
               type: Utilization
               averageUtilization: 80
 
+  gateway:
+    enabled: false
+    fullnameOverride: ""
+    extraLabels: {}
+
+    container:
+      command: []
+      args: []
+
+    service:
+      enabled: true
+      type: ClusterIP
+      port: 80
+      targetPort: 80
+      externalTrafficPolicy: ""
+      clusterIP: ""
+
+    ingress:
+      enabled: false
+      ingressClassName: nginx
+      annotations: {}
+      hosts:
+        - host: "*.sites.example.com"
+          paths:
+            - /
+      defaultBackend: {}
+
+    networkPolicy:
+      enabled: false
+      ingress: []
+      egress: []
+
+    deployment:
+      replicaCount: 2
+      resources:
+        limits:
+          cpu: 2000m
+          memory: 4000Mi
+          ephemeral-storage: 1Gi
+        requests:
+          cpu: 200m
+          memory: 512Mi
+          ephemeral-storage: 400Mi
+      extraEnv:
+        - name: LIFECYCLE_MODE
+          value: gateway
+      envFrom: {}
+
+      ports:
+        - name: http
+          containerPort: 80
+          protocol: TCP
+      livenessProbe:
+        httpGet:
+          path: /api/health
+          port: http
+        initialDelaySeconds: 60
+        periodSeconds: 10
+        failureThreshold: 6
+      readinessProbe:
+        httpGet:
+          path: /api/health
+          port: http
+        periodSeconds: 5
+        failureThreshold: 3
+      nodeSelector: {}
+      tolerations: []
+      affinity: {}
+      volumes: []
+      volumeMounts: []
+      startupProbe: {}
+
+    pdb:
+      enabled: false
+      minAvailable: 1
+
+    hpa:
+      enabled: false
+      minReplicas: 2
+      maxReplicas: 10
+      metrics:
+        - type: Resource
+          resource:
+            name: cpu
+            target:
+              type: Utilization
+              averageUtilization: 80
+
 externalDatabase:
   enabled: false
   host:


### PR DESCRIPTION
## Summary

Adds Helm chart support for running the Lifecycle static sites gateway as its own component.

- Adds a disabled-by-default `components.gateway` values block with deployment, service, ingress, networkPolicy, PDB, and HPA options.
- Sets gateway defaults for `LIFECYCLE_MODE=gateway`, port `80`, health probes, and conservative resources.
- Fixes component HPA scale target names so component HPAs target their own deployment.
- Tightens PDB and NetworkPolicy selectors to include `app.kubernetes.io/component`.
- Bumps the lifecycle chart version from `0.9.6` to `0.9.7`.

## Validation

Passed:

- `helm lint charts/lifecycle`
- `helm template` with gateway deployment/service/ingress/HPA/PDB enabled
- `git diff --check`

Notes:

- `helm lint` still emits the existing Keycloak Operator CRD informational warning, but reports `0 chart(s) failed`.
