### PR TITLE
add admin role mapping and internal IdP URL override

### DIFF
--- a/charts/lifecycle-keycloak/Chart.yaml
+++ b/charts/lifecycle-keycloak/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: lifecycle-keycloak
 description: Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports
 type: application
-version: 0.7.3
+version: 0.7.4
 appVersion: 0.0.0
 home: https://goodrxoss.github.io/helm-charts/charts/lifecycle-keycloak/
 

--- a/charts/lifecycle-keycloak/templates/internal-realm-kri.yaml
+++ b/charts/lifecycle-keycloak/templates/internal-realm-kri.yaml
@@ -35,9 +35,16 @@ spec:
     sslRequired: "external"
     registrationAllowed: false
     duplicateEmailsAllowed: false
-    resetPasswordAllowed": false
+    resetPasswordAllowed: false
     loginWithEmailAllowed: true
     loginTheme: "lifecycle"  # ref for login-theme-configmap.yaml
+    {{- if .Values.internalIdp.mapAdminRole }}
+    # --- REALM ROLES ---
+    roles:
+      realm:
+        - name: "admin"
+          description: "Administrator role with elevated privileges"
+    {{- end }}
     accountTheme: "keycloak"
     adminTheme: "keycloak"
     emailTheme: "keycloak"
@@ -50,6 +57,10 @@ spec:
         emailVerified: true
         firstName: {{ .Values.internalIdp.users.bootstrapUser.firstName | quote }}
         lastName: {{ .Values.internalIdp.users.bootstrapUser.lastName | quote }}
+        {{- if .Values.internalIdp.mapAdminRole }}
+        realmRoles:
+          - "admin"
+        {{- end }}
         credentials:
           - type: "password"
             value: {{ .Values.internalIdp.users.bootstrapUser.password | quote }}
@@ -65,7 +76,7 @@ spec:
         clientAuthenticatorType: "client-jwt"
         attributes:
           use.jwks.url: "true"
-          jwks.url: {{ printf "%s/realms/%s/protocol/openid-connect/certs" .Values.hostname .Values.realm | quote }}
+          jwks.url: {{ printf "%s/realms/%s/protocol/openid-connect/certs" ( .Values.internalIdp.internalUrl | default .Values.hostname ) .Values.realm | quote }}
           token.endpoint.auth.signing.alg: "RS256"
         publicClient: false
         redirectUris:
@@ -78,3 +89,16 @@ spec:
         authorizationServicesEnabled: false
         defaultClientScopes: ["web-origins", "acr", "roles", "profile", "basic", "email"]
         optionalClientScopes: ["address", "phone", "offline_access", "organization", "microprofile-jwt"]
+        {{- if .Values.internalIdp.mapAdminRole }}
+        protocolMappers:
+          - name: "realm roles"
+            protocol: "openid-connect"
+            protocolMapper: "oidc-usermodel-realm-role-mapper"
+            config:
+              claim.name: "realm_access.roles"
+              jsonType.label: "String"
+              multivalued: "true"
+              id.token.claim: "true"
+              access.token.claim: "true"
+              userinfo.token.claim: "true"
+        {{- end }}

--- a/charts/lifecycle-keycloak/templates/lifecycle-realm-kri.yaml
+++ b/charts/lifecycle-keycloak/templates/lifecycle-realm-kri.yaml
@@ -141,8 +141,8 @@ spec:
           clientId: {{ .Values.internalIdp.clientId | quote }}
           clientAuthMethod: "private_key_jwt"
           clientAssertionSigningAlg: "RS256"
-          tokenUrl: {{ printf "%s/realms/%s/protocol/openid-connect/token" .Values.hostname .Values.internalIdp.realm | quote }}
-          jwksUrl: {{ printf "%s/realms/%s/protocol/openid-connect/certs" .Values.hostname .Values.internalIdp.realm | quote }}
+          tokenUrl: {{ printf "%s/realms/%s/protocol/openid-connect/token" ( .Values.internalIdp.internalUrl | default .Values.hostname ) .Values.internalIdp.realm | quote }}
+          jwksUrl: {{ printf "%s/realms/%s/protocol/openid-connect/certs" ( .Values.internalIdp.internalUrl | default .Values.hostname ) .Values.internalIdp.realm | quote }}
           authorizationUrl: {{ printf "%s/realms/%s/protocol/openid-connect/auth" .Values.hostname .Values.internalIdp.realm | quote }}
           logoutUrl: {{ printf "%s/realms/%s/protocol/openid-connect/logout" .Values.hostname .Values.internalIdp.realm | quote }}
           clientAssertionAudience: {{ printf "%s/realms/%s" .Values.hostname .Values.internalIdp.realm | quote }}
@@ -175,6 +175,17 @@ spec:
           syncMode: "LEGACY"
 
     identityProviderMappers:
+      {{- if .Values.internalIdp.mapAdminRole }}
+      - name: "Admin Role Mapper"
+        identityProviderAlias: "company-sso"
+        identityProviderMapper: "oidc-role-idp-mapper"
+        config:
+          syncMode: "FORCE"
+          claim: "realm_access.roles"
+          claim.value: "admin"
+          role: "admin"
+      {{- end }}
+
       - name: "Github username"
         identityProviderAlias: "github"
         identityProviderMapper: "github-user-attribute-mapper"
@@ -190,6 +201,7 @@ spec:
           syncMode: "FORCE"
           userAttribute: "githubProfilePicture"
           jsonField: "avatar_url"
+
 
     # --- COMPONENTS (USER PROFILE) ---
     components:

--- a/charts/lifecycle-keycloak/values.yaml
+++ b/charts/lifecycle-keycloak/values.yaml
@@ -64,6 +64,8 @@ internalIdp:
   realm: internal
   displayName: "Internal SSO"
   clientId: internal-sso-client
+  internalUrl: ""
+  mapAdminRole: false
   users:
     bootstrapUser:
       username: lifecycle
@@ -72,6 +74,7 @@ internalIdp:
       lastName: Bootstrap
       password: lifecycle
       credsTemp: true
+
 
 instances: 1
 


### PR DESCRIPTION
- New internalIdp.mapAdminRole flag (default false) — opt-in end-to-end admin role propagation:
    - Defines a realm admin role on the internal realm
    - Grants it to the bootstrap user
    - Adds a realm-role protocol mapper to the internal-sso client so realm_access.roles is emitted in ID/access/userinfo tokens
    - Adds an oidc-role-idp-mapper ("Admin Role Mapper", syncMode: FORCE) so an admin claim from the upstream company SSO maps into the local admin role
  - New internalIdp.internalUrl value (default "") — lets service-to-service endpoints (tokenUrl / jwksUrl in both internal and lifecycle realms) resolve to a cluster-internal address while public-facing URLs stay on hostname.
  Falls back to hostname when unset, so existing deployments are unaffected.
  - Bug fix: malformed YAML key — resetPasswordAllowed": false had a stray quote, corrupting the realm spec key. Now resetPasswordAllowed: false.
  - Chart version bump 0.7.3 → 0.7.4.