### PR TITLE
feat(lifecycle-keycloak): principal-sync client for API key owner off…

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ A collection of Helm charts primarily used for **Lifecycle** application deploym
 | :--- | :--- | :--- | :--- |
 | [keycloak-operator](./charts/keycloak-operator) | `0.1.0` | `26.4.7` | Helm chart for Keycloak operator based on the [official manifests](https://www.keycloak.org/operator/installation#_installing_by_using_kubectl_without_operator_lifecycle_manager) |
 | [lifecycle](./charts/lifecycle) | `0.9.9` | `0.1.15` | A Helm umbrella chart for full Lifecycle stack |
-| [lifecycle-keycloak](./charts/lifecycle-keycloak) | `0.7.4` | `0.0.0` | Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports |
+| [lifecycle-keycloak](./charts/lifecycle-keycloak) | `0.7.5` | `0.0.0` | Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports |
 | [lifecycle-ui](./charts/lifecycle-ui) | `0.3.3` | `0.1.5` | A Helm chart for Lifecycle UI (Next.js) |

--- a/charts/lifecycle-keycloak/Chart.yaml
+++ b/charts/lifecycle-keycloak/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: lifecycle-keycloak
 description: Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports
 type: application
-version: 0.7.4
+version: 0.7.5
 appVersion: 0.0.0
 home: https://goodrxoss.github.io/helm-charts/charts/lifecycle-keycloak/
 

--- a/charts/lifecycle-keycloak/README.md
+++ b/charts/lifecycle-keycloak/README.md
@@ -1,6 +1,6 @@
 # lifecycle-keycloak
 
-![Version: 0.7.4](https://img.shields.io/badge/Version-0.7.4-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 0.7.5](https://img.shields.io/badge/Version-0.7.5-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports
 
@@ -128,7 +128,7 @@ This chart uses the `KeycloakRealmImport` resource for the initial setup.
 ```shell
 helm upgrade -i lifecycle-keycloak \
   oci://ghcr.io/goodrxoss/helm-charts/lifecycle-keycloak \
-  --version 0.7.4 \
+  --version 0.7.5 \
   -f values.yaml \
   -n lifecycle-keycloak \
   --create-namespace
@@ -139,6 +139,10 @@ helm upgrade -i lifecycle-keycloak \
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | annotations | object | `{}` |  |
+| clients.lifecycleApiPrincipalSync.clientId | string | `"lifecycle-api-principal-sync"` |  |
+| clients.lifecycleApiPrincipalSync.clientSecret.secretKeyRef.key | string | `nil` |  |
+| clients.lifecycleApiPrincipalSync.clientSecret.secretKeyRef.name | string | `nil` |  |
+| clients.lifecycleApiPrincipalSync.enabled | bool | `true` |  |
 | clients.lifecycleCli.clientId | string | `"lifecycle-cli"` |  |
 | clients.lifecycleCli.enabled | bool | `true` |  |
 | clients.lifecycleCore.clientId | string | `"lifecycle-core"` |  |
@@ -213,6 +217,10 @@ helm upgrade -i lifecycle-keycloak \
 | parentChartName | string | `"lifecycle"` |  |
 | realm | string | `"lifecycle"` |  |
 | realmDisplayName | string | `"Lifecycle"` |  |
+| secrets.apiPrincipalSync.annotations | list | `[]` |  |
+| secrets.apiPrincipalSync.clientSecret | string | `nil` |  |
+| secrets.apiPrincipalSync.enabled | bool | `true` |  |
+| secrets.apiPrincipalSync.fullnameOverride | string | `""` |  |
 | secrets.bootstrapAdmin.annotations | list | `[]` |  |
 | secrets.bootstrapAdmin.enabled | bool | `true` |  |
 | secrets.bootstrapAdmin.fullnameOverride | string | `""` |  |

--- a/charts/lifecycle-keycloak/templates/_helpers.tpl
+++ b/charts/lifecycle-keycloak/templates/_helpers.tpl
@@ -107,6 +107,15 @@ Namespace Hostname
 {{- end -}}
 {{- end -}}
 
+{{- define "lifecycle-keycloak.apiPrincipalSyncSecretName" -}}
+{{- if .Values.secrets.apiPrincipalSync.fullnameOverride -}}
+    {{- .Values.secrets.apiPrincipalSync.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+    {{- $prefix := include "lifecycle-keycloak.fullname" . -}}
+    {{- printf "%s-%s" $prefix "api-principal-sync" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "lifecycle-keycloak.postgresSvcPrefix" -}}
 {{- if .Values.keycloakPostgres.fullnameOverride }}
     {{- printf "%s.%s" .Values.keycloakPostgres.fullnameOverride (include "lifecycle-keycloak.namespaceHostname" .) }}

--- a/charts/lifecycle-keycloak/templates/api-principal-sync-secret.yaml
+++ b/charts/lifecycle-keycloak/templates/api-principal-sync-secret.yaml
@@ -1,0 +1,45 @@
+{{- /*
+Copyright 2026 GoodRx, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- $namespace := .Release.Namespace -}}
+{{- $secretName := printf "%s" (include "lifecycle-keycloak.apiPrincipalSyncSecretName" .) -}}
+{{- $apiVersion := "v1" -}}
+{{- $component := "keycloak" -}}
+
+{{- /* pre-upgrade too: the env ref on the Keycloak pod must resolve on upgrades of pre-existing releases. */}}
+{{- if and .Values.secrets.apiPrincipalSync.enabled (not (lookup $apiVersion "Secret" $namespace $secretName)) }}
+{{- with .Values.secrets.apiPrincipalSync -}}
+apiVersion: {{ $apiVersion }}
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ $namespace }}
+  labels:
+    {{- include "lifecycle-keycloak.labels" (merge (dict "component" $component) $) | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/resource-policy": keep
+  {{- with .annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  {{- with . }}
+  clientSecret: {{ .clientSecret | default (randAlphaNum 40) | b64enc | quote }}
+  {{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/lifecycle-keycloak/templates/keycloak-instance.yaml
+++ b/charts/lifecycle-keycloak/templates/keycloak-instance.yaml
@@ -106,6 +106,13 @@ spec:
                   secretKeyRef:
                     name: {{ tpl (.Values.clients.lifecycleUi.clientSecret.secretKeyRef.name | default (include "lifecycle-keycloak.lifecycleUiSecretName" .)) . | quote }}
                     key: {{ .Values.clients.lifecycleUi.clientSecret.secretKeyRef.key | default "clientSecret" | quote }}
+              {{- if .Values.clients.lifecycleApiPrincipalSync.enabled }}
+              - name: LIFECYCLE_API_PRINCIPAL_SYNC_CLIENT_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ tpl (.Values.clients.lifecycleApiPrincipalSync.clientSecret.secretKeyRef.name | default (include "lifecycle-keycloak.apiPrincipalSyncSecretName" .)) . | quote }}
+                    key: {{ .Values.clients.lifecycleApiPrincipalSync.clientSecret.secretKeyRef.key | default "clientSecret" | quote }}
+              {{- end }}
             volumeMounts:
               - name: vault-volume
                 mountPath: /opt/keycloak/vault

--- a/charts/lifecycle-keycloak/templates/lifecycle-realm-kri.yaml
+++ b/charts/lifecycle-keycloak/templates/lifecycle-realm-kri.yaml
@@ -185,6 +185,43 @@ spec:
               introspection.token.claim: "true"
       {{- end }}
 
+      {{- if .Values.clients.lifecycleApiPrincipalSync.enabled }}
+      - clientId: {{ .Values.clients.lifecycleApiPrincipalSync.clientId | quote }}
+        name: "Lifecycle API principal sync"
+        description: "Confidential service-account client the Lifecycle API uses to detect disabled or deleted owners of personal API keys"
+        enabled: true
+        publicClient: false
+        clientAuthenticatorType: "client-secret"
+        secret: "${LIFECYCLE_API_PRINCIPAL_SYNC_CLIENT_SECRET}"
+        protocol: "openid-connect"
+        serviceAccountsEnabled: true
+        standardFlowEnabled: false
+        implicitFlowEnabled: false
+        directAccessGrantsEnabled: false
+        fullScopeAllowed: false
+        defaultClientScopes: ["roles", "basic"]
+      {{- end }}
+
+    {{- if .Values.clients.lifecycleApiPrincipalSync.enabled }}
+    # --- SERVICE ACCOUNTS ---
+    users:
+      - username: {{ printf "service-account-%s" .Values.clients.lifecycleApiPrincipalSync.clientId | quote }}
+        enabled: true
+        serviceAccountClientId: {{ .Values.clients.lifecycleApiPrincipalSync.clientId | quote }}
+        clientRoles:
+          realm-management:
+            - "view-users"
+            - "query-users"
+
+    # fullScopeAllowed is off, so this scope mapping is what lets the two roles into the token.
+    clientScopeMappings:
+      realm-management:
+        - client: {{ .Values.clients.lifecycleApiPrincipalSync.clientId | quote }}
+          roles:
+            - "view-users"
+            - "query-users"
+    {{- end }}
+
     # --- IDENTITY PROVIDERS ---
     identityProviders:
       - alias: "company-sso"

--- a/charts/lifecycle-keycloak/values.yaml
+++ b/charts/lifecycle-keycloak/values.yaml
@@ -45,6 +45,16 @@ clients:
     enabled: true
     clientId: lifecycle-cli
 
+  # Confidential service-account client the Lifecycle API uses to revoke personal
+  # API keys of disabled/deleted owners (realm-management view-users + query-users only).
+  lifecycleApiPrincipalSync:
+    enabled: true
+    clientId: lifecycle-api-principal-sync
+    clientSecret:
+      secretKeyRef:
+        name:  # fallback to "{{ include "lifecycle-keycloak.apiPrincipalSyncSecretName" . }}"
+        key:  # default "clientSecret"
+
 
 companyIdp:
   enabled: true
@@ -133,6 +143,12 @@ secrets:
     clientSecret:
 
   lifecycleUi:
+    enabled: true
+    fullnameOverride: ""
+    annotations: []
+    clientSecret:
+
+  apiPrincipalSync:
     enabled: true
     fullnameOverride: ""
     annotations: []


### PR DESCRIPTION
…boarding

Adds the lifecycle-api-principal-sync confidential service-account client (realm-management view-users and query-users only) to the realm import, a chart-managed client secret, and the secret env on the Keycloak instance so the import placeholder resolves. The Lifecycle API uses this client to deactivate personal API keys whose owners are disabled or deleted. Bumps lifecycle-keycloak to 0.7.5.