### PR TITLE
feat(lifecycle-keycloak): add MCP management client

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -16,4 +16,11 @@ jobs:
         with:
           python-version: '3.x'
 
+      - uses: azure/setup-helm@v3
+        with:
+          version: v3.14.0
+
+      - name: Verify Keycloak credential Secret isolation
+        run: bash scripts/test-keycloak-credential-isolation.sh
+
       - uses: pre-commit/action@v3.0.1

--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ A collection of Helm charts primarily used for **Lifecycle** application deploym
 | :--- | :--- | :--- | :--- |
 | [keycloak-operator](./charts/keycloak-operator) | `0.1.0` | `26.4.7` | Helm chart for Keycloak operator based on the [official manifests](https://www.keycloak.org/operator/installation#_installing_by_using_kubectl_without_operator_lifecycle_manager) |
 | [lifecycle](./charts/lifecycle) | `0.9.10` | `0.1.15` | A Helm umbrella chart for full Lifecycle stack |
-| [lifecycle-keycloak](./charts/lifecycle-keycloak) | `0.7.5` | `0.0.0` | Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports |
+| [lifecycle-keycloak](./charts/lifecycle-keycloak) | `0.7.6` | `0.0.0` | Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports |
 | [lifecycle-ui](./charts/lifecycle-ui) | `0.3.3` | `0.1.5` | A Helm chart for Lifecycle UI (Next.js) |

--- a/charts/lifecycle-keycloak/Chart.yaml
+++ b/charts/lifecycle-keycloak/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: lifecycle-keycloak
 description: Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports
 type: application
-version: 0.7.5
+version: 0.7.6
 appVersion: 0.0.0
 home: https://goodrxoss.github.io/helm-charts/charts/lifecycle-keycloak/
 

--- a/charts/lifecycle-keycloak/README.md
+++ b/charts/lifecycle-keycloak/README.md
@@ -1,6 +1,6 @@
 # lifecycle-keycloak
 
-![Version: 0.7.5](https://img.shields.io/badge/Version-0.7.5-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 0.7.6](https://img.shields.io/badge/Version-0.7.6-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 Keycloak instance for Lifecycle stack with automated Operator-driven setup and imports
 
@@ -94,32 +94,133 @@ You **must** provide the actual domains during installation. These are used for 
 * `hostname`: The main entry point for Keycloak (e.g., `https://keycloak.example.com`).
 * `clients.lifecycleUi.url`: The frontend application URL (e.g., `https://ui.example.com`).
 
-### 3. Client Secrets (Bootstrap Only)
+### 3. Lifecycle API Credentials
 
-You can define initial secrets for your clients:
+This chart bootstraps two fixed, confidential service-account clients:
+
+* `lifecycle-api-keycloak-management` is directly assigned only
+  `manage-clients` and `manage-realm` for the Lifecycle web process. Keycloak
+  expands the built-in `manage-realm` composites in its token.
+* `lifecycle-api-principal-sync` is directly assigned only `view-users` and
+  `query-users` for the Lifecycle worker. On Keycloak 26.4.7, `query-users`
+  also adds its built-in `query-groups` composite to the token.
+
+Their Kubernetes Secrets are lookup-stable and remain in place during rollback.
+`KeycloakRealmImport` creates the clients during the initial realm import. The
+Lifecycle API, not this chart, configures MCP scopes, audiences, and dynamic
+client registration when an administrator enables MCP.
+
+Use existing Secrets when another secret manager owns the values:
 
 ```yaml
 clients:
-  lifecycleCore:
-    clientSecret: "lifecycle-core-secret"
-  lifecycleUi:
-    clientSecret: "lifecycle-ui-secret"
-  lifecycleUiBackend:
-    clientSecret: "lifecycle-ui-backend-secret"
+  lifecycleApiKeycloakManagement:
+    clientSecret:
+      secretKeyRef:
+        name: lifecycle-api-keycloak-management
+        key: clientSecret
+  lifecycleApiPrincipalSync:
+    clientSecret:
+      secretKeyRef:
+        name: lifecycle-api-principal-sync
+        key: clientSecret
+
+secrets:
+  apiKeycloakManagement:
+    enabled: false
+  apiPrincipalSync:
+    enabled: false
 
 ```
 
-> **Important:** These values act as **bootstrap** values. After the initial creation, if you change them in the Keycloak Admin UI, the values in Helm will no longer stay in sync.
+`KeycloakRealmImport` is one-shot: upgrading an installation whose Lifecycle
+realm already exists will not add either client. Create the missing clients
+externally before enabling MCP (`lifecycle-api-keycloak-management`) or relying
+on the API-key owner sweep (`lifecycle-api-principal-sync`). Each is an enabled
+confidential OpenID Connect service-account client with interactive and
+direct-access flows disabled, `fullScopeAllowed: false`, and scope mappings for
+exactly its `realm-management` roles: `manage-clients` + `manage-realm` for the
+management client, `view-users` + `query-users` for principal sync. Each client
+secret must match the Kubernetes Secret selected by the corresponding
+`clients.*.clientSecret.secretKeyRef`.
+
+#### Existing-realm MCP policy migration and recovery
+
+This chart bootstraps credentials and fresh-realm clients only. The Lifecycle
+web/API process performs MCP Keycloak reconciliation when an administrator
+enables MCP; a Helm install or upgrade does not reconcile or repair dynamic
+client-registration policies.
+
+On enable, Lifecycle reconciles and verifies its MCP scopes, mappers, profiles,
+policies, and anonymous registration components. It may remove the anonymous
+`Trusted Hosts` component only when exactly one exists and it matches the stock
+Keycloak posture: both `host-sending-registration-request-must-match` and
+`client-uris-must-match` are `true`. Lifecycle never overwrites, removes, or
+replaces a customized, duplicated, or otherwise drifted `Trusted Hosts` policy.
+Such a conflict fails enablement safely and requires a Keycloak operator to
+restore an unambiguous compatible posture before the administrator retries.
+
+Disabling Lifecycle MCP closes Lifecycle MCP access only. It does not delete or
+revert the Keycloak objects created during enablement, and it does not restore a
+stock `Trusted Hosts` component that enablement removed. Re-enabling MCP runs
+the full reconciliation and verification again. Treat this realm configuration
+as durable; disabling MCP or upgrading this chart is not a Keycloak recovery
+operation.
+
+With `kcadm.sh` (repeat the block with `C=lifecycle-api-principal-sync` and
+`ROLES="view-users query-users"` for the second client):
+
+```bash
+REALM=lifecycle
+C=lifecycle-api-keycloak-management
+ROLES="manage-clients manage-realm"
+SECRET=... # the value from the client's Kubernetes Secret
+
+kcadm.sh create clients -r "$REALM" -s clientId="$C" -s protocol=openid-connect \
+  -s publicClient=false -s serviceAccountsEnabled=true -s standardFlowEnabled=false \
+  -s implicitFlowEnabled=false -s directAccessGrantsEnabled=false \
+  -s fullScopeAllowed=false -s secret="$SECRET"
+
+kcadm.sh add-roles -r "$REALM" --uusername "service-account-$C" \
+  --cclientid realm-management $(printf -- '--rolename %s ' $ROLES)
+
+CID=$(kcadm.sh get clients -r "$REALM" -q clientId="$C" --fields id --format csv --noquotes)
+RMID=$(kcadm.sh get clients -r "$REALM" -q clientId=realm-management --fields id --format csv --noquotes)
+for ROLE in $ROLES; do
+  R=$(kcadm.sh get "clients/$RMID/roles/$ROLE" -r "$REALM" --fields id,name)
+  kcadm.sh create "clients/$CID/scope-mappings/clients/$RMID" -r "$REALM" -b "[$R]"
+done
+```
+
+The preferred migration path is to let an external secret manager supply the
+Kubernetes Secrets (`secrets.apiKeycloakManagement.enabled: false`,
+`secrets.apiPrincipalSync.enabled: false`) and use the same secret source when
+creating the Keycloak clients. This avoids printing or decoding the
+credentials. If the chart-generated Secrets are used instead, the one-time
+administrator automation should read them directly from the Kubernetes API
+without logging them.
+
+The chart preserves the distinguishing Secret-name suffixes for long release
+names and rejects any configuration that resolves both credentials to the same
+Secret key. External Secrets may hold both credentials under distinct keys.
+Chart-generated credential Secrets use
+`helm.sh/resource-policy: keep`, so uninstalling the release does not remove
+them. If the Keycloak realm is retained, revoke or delete the matching clients
+before deleting the retained Secrets. Rotate a credential by updating its
+Keycloak client and Kubernetes Secret as one coordinated operation, then
+restart only the owning Lifecycle process (`web` for management, `worker` for
+principal sync). `KeycloakRealmImport` is one-shot, so changing a Helm value
+alone does not rotate an existing client.
 
 ---
 
-## Life-cycle Management & Realm Import
+## Lifecycle Management & Realm Import
 
 This chart uses the `KeycloakRealmImport` resource for the initial setup.
 
-* **Immutable Configuration:** Some settings (like certain realm links or fundamental structures) are hard to modify via the Operator after the initial import.
-* **Re-initialization:** If you need to significantly change the realm structure that isn't being picked up by the Operator, you may need to **delete the Helm release and reinstall it**.
-* **Caution:** Deleting the release might trigger the deletion of the Keycloak instance and its data (PostgreSQL), depending on your `persistence` and `reclaimPolicy` settings.
+* **Initial import only:** Changes to the import do not reconcile an existing realm.
+* **Existing realms:** Apply required additions through an external Keycloak administration process.
+* **Caution:** Deleting the release to force a new import can delete the Keycloak instance and its data, depending on persistence and reclaim-policy settings.
 
 ---
 
@@ -128,7 +229,7 @@ This chart uses the `KeycloakRealmImport` resource for the initial setup.
 ```shell
 helm upgrade -i lifecycle-keycloak \
   oci://ghcr.io/goodrxoss/helm-charts/lifecycle-keycloak \
-  --version 0.7.5 \
+  --version 0.7.6 \
   -f values.yaml \
   -n lifecycle-keycloak \
   --create-namespace
@@ -139,10 +240,14 @@ helm upgrade -i lifecycle-keycloak \
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | annotations | object | `{}` |  |
-| clients.lifecycleApiPrincipalSync.clientId | string | `"lifecycle-api-principal-sync"` |  |
+| clients.lifecycleApiKeycloakManagement.clientId | string | `"lifecycle-api-keycloak-management"` | Keycloak client ID for the web-only management credential. |
+| clients.lifecycleApiKeycloakManagement.clientSecret.secretKeyRef.key | string | `nil` |  |
+| clients.lifecycleApiKeycloakManagement.clientSecret.secretKeyRef.name | string | `nil` |  |
+| clients.lifecycleApiKeycloakManagement.enabled | bool | `true` | Bootstrap the web-only Lifecycle API Keycloak-management credential. |
+| clients.lifecycleApiPrincipalSync.clientId | string | `"lifecycle-api-principal-sync"` | Keycloak client ID for the worker-only principal-sync credential. |
 | clients.lifecycleApiPrincipalSync.clientSecret.secretKeyRef.key | string | `nil` |  |
 | clients.lifecycleApiPrincipalSync.clientSecret.secretKeyRef.name | string | `nil` |  |
-| clients.lifecycleApiPrincipalSync.enabled | bool | `true` |  |
+| clients.lifecycleApiPrincipalSync.enabled | bool | `true` | Bootstrap the worker-only read-only principal-sync credential. |
 | clients.lifecycleCli.clientId | string | `"lifecycle-cli"` |  |
 | clients.lifecycleCli.enabled | bool | `true` |  |
 | clients.lifecycleCore.clientId | string | `"lifecycle-core"` |  |
@@ -217,9 +322,13 @@ helm upgrade -i lifecycle-keycloak \
 | parentChartName | string | `"lifecycle"` |  |
 | realm | string | `"lifecycle"` |  |
 | realmDisplayName | string | `"Lifecycle"` |  |
-| secrets.apiPrincipalSync.annotations | list | `[]` |  |
+| secrets.apiKeycloakManagement.annotations | object | `{}` |  |
+| secrets.apiKeycloakManagement.clientSecret | string | `nil` |  |
+| secrets.apiKeycloakManagement.enabled | bool | `true` | Create the lookup-stable Keycloak-management client Secret. |
+| secrets.apiKeycloakManagement.fullnameOverride | string | `""` |  |
+| secrets.apiPrincipalSync.annotations | object | `{}` |  |
 | secrets.apiPrincipalSync.clientSecret | string | `nil` |  |
-| secrets.apiPrincipalSync.enabled | bool | `true` |  |
+| secrets.apiPrincipalSync.enabled | bool | `true` | Create the lookup-stable principal-sync client Secret. |
 | secrets.apiPrincipalSync.fullnameOverride | string | `""` |  |
 | secrets.bootstrapAdmin.annotations | list | `[]` |  |
 | secrets.bootstrapAdmin.enabled | bool | `true` |  |

--- a/charts/lifecycle-keycloak/README.md.gotmpl
+++ b/charts/lifecycle-keycloak/README.md.gotmpl
@@ -92,32 +92,133 @@ You **must** provide the actual domains during installation. These are used for 
 * `hostname`: The main entry point for Keycloak (e.g., `https://keycloak.example.com`).
 * `clients.lifecycleUi.url`: The frontend application URL (e.g., `https://ui.example.com`).
 
-### 3. Client Secrets (Bootstrap Only)
+### 3. Lifecycle API Credentials
 
-You can define initial secrets for your clients:
+This chart bootstraps two fixed, confidential service-account clients:
+
+* `lifecycle-api-keycloak-management` is directly assigned only
+  `manage-clients` and `manage-realm` for the Lifecycle web process. Keycloak
+  expands the built-in `manage-realm` composites in its token.
+* `lifecycle-api-principal-sync` is directly assigned only `view-users` and
+  `query-users` for the Lifecycle worker. On Keycloak 26.4.7, `query-users`
+  also adds its built-in `query-groups` composite to the token.
+
+Their Kubernetes Secrets are lookup-stable and remain in place during rollback.
+`KeycloakRealmImport` creates the clients during the initial realm import. The
+Lifecycle API, not this chart, configures MCP scopes, audiences, and dynamic
+client registration when an administrator enables MCP.
+
+Use existing Secrets when another secret manager owns the values:
 
 ```yaml
 clients:
-  lifecycleCore:
-    clientSecret: "lifecycle-core-secret"
-  lifecycleUi:
-    clientSecret: "lifecycle-ui-secret"
-  lifecycleUiBackend:
-    clientSecret: "lifecycle-ui-backend-secret"
+  lifecycleApiKeycloakManagement:
+    clientSecret:
+      secretKeyRef:
+        name: lifecycle-api-keycloak-management
+        key: clientSecret
+  lifecycleApiPrincipalSync:
+    clientSecret:
+      secretKeyRef:
+        name: lifecycle-api-principal-sync
+        key: clientSecret
+
+secrets:
+  apiKeycloakManagement:
+    enabled: false
+  apiPrincipalSync:
+    enabled: false
 
 ```
 
-> **Important:** These values act as **bootstrap** values. After the initial creation, if you change them in the Keycloak Admin UI, the values in Helm will no longer stay in sync.
+`KeycloakRealmImport` is one-shot: upgrading an installation whose Lifecycle
+realm already exists will not add either client. Create the missing clients
+externally before enabling MCP (`lifecycle-api-keycloak-management`) or relying
+on the API-key owner sweep (`lifecycle-api-principal-sync`). Each is an enabled
+confidential OpenID Connect service-account client with interactive and
+direct-access flows disabled, `fullScopeAllowed: false`, and scope mappings for
+exactly its `realm-management` roles: `manage-clients` + `manage-realm` for the
+management client, `view-users` + `query-users` for principal sync. Each client
+secret must match the Kubernetes Secret selected by the corresponding
+`clients.*.clientSecret.secretKeyRef`.
+
+#### Existing-realm MCP policy migration and recovery
+
+This chart bootstraps credentials and fresh-realm clients only. The Lifecycle
+web/API process performs MCP Keycloak reconciliation when an administrator
+enables MCP; a Helm install or upgrade does not reconcile or repair dynamic
+client-registration policies.
+
+On enable, Lifecycle reconciles and verifies its MCP scopes, mappers, profiles,
+policies, and anonymous registration components. It may remove the anonymous
+`Trusted Hosts` component only when exactly one exists and it matches the stock
+Keycloak posture: both `host-sending-registration-request-must-match` and
+`client-uris-must-match` are `true`. Lifecycle never overwrites, removes, or
+replaces a customized, duplicated, or otherwise drifted `Trusted Hosts` policy.
+Such a conflict fails enablement safely and requires a Keycloak operator to
+restore an unambiguous compatible posture before the administrator retries.
+
+Disabling Lifecycle MCP closes Lifecycle MCP access only. It does not delete or
+revert the Keycloak objects created during enablement, and it does not restore a
+stock `Trusted Hosts` component that enablement removed. Re-enabling MCP runs
+the full reconciliation and verification again. Treat this realm configuration
+as durable; disabling MCP or upgrading this chart is not a Keycloak recovery
+operation.
+
+With `kcadm.sh` (repeat the block with `C=lifecycle-api-principal-sync` and
+`ROLES="view-users query-users"` for the second client):
+
+```bash
+REALM=lifecycle
+C=lifecycle-api-keycloak-management
+ROLES="manage-clients manage-realm"
+SECRET=... # the value from the client's Kubernetes Secret
+
+kcadm.sh create clients -r "$REALM" -s clientId="$C" -s protocol=openid-connect \
+  -s publicClient=false -s serviceAccountsEnabled=true -s standardFlowEnabled=false \
+  -s implicitFlowEnabled=false -s directAccessGrantsEnabled=false \
+  -s fullScopeAllowed=false -s secret="$SECRET"
+
+kcadm.sh add-roles -r "$REALM" --uusername "service-account-$C" \
+  --cclientid realm-management $(printf -- '--rolename %s ' $ROLES)
+
+CID=$(kcadm.sh get clients -r "$REALM" -q clientId="$C" --fields id --format csv --noquotes)
+RMID=$(kcadm.sh get clients -r "$REALM" -q clientId=realm-management --fields id --format csv --noquotes)
+for ROLE in $ROLES; do
+  R=$(kcadm.sh get "clients/$RMID/roles/$ROLE" -r "$REALM" --fields id,name)
+  kcadm.sh create "clients/$CID/scope-mappings/clients/$RMID" -r "$REALM" -b "[$R]"
+done
+```
+
+The preferred migration path is to let an external secret manager supply the
+Kubernetes Secrets (`secrets.apiKeycloakManagement.enabled: false`,
+`secrets.apiPrincipalSync.enabled: false`) and use the same secret source when
+creating the Keycloak clients. This avoids printing or decoding the
+credentials. If the chart-generated Secrets are used instead, the one-time
+administrator automation should read them directly from the Kubernetes API
+without logging them.
+
+The chart preserves the distinguishing Secret-name suffixes for long release
+names and rejects any configuration that resolves both credentials to the same
+Secret key. External Secrets may hold both credentials under distinct keys.
+Chart-generated credential Secrets use
+`helm.sh/resource-policy: keep`, so uninstalling the release does not remove
+them. If the Keycloak realm is retained, revoke or delete the matching clients
+before deleting the retained Secrets. Rotate a credential by updating its
+Keycloak client and Kubernetes Secret as one coordinated operation, then
+restart only the owning Lifecycle process (`web` for management, `worker` for
+principal sync). `KeycloakRealmImport` is one-shot, so changing a Helm value
+alone does not rotate an existing client.
 
 ---
 
-## Life-cycle Management & Realm Import
+## Lifecycle Management & Realm Import
 
 This chart uses the `KeycloakRealmImport` resource for the initial setup.
 
-* **Immutable Configuration:** Some settings (like certain realm links or fundamental structures) are hard to modify via the Operator after the initial import.
-* **Re-initialization:** If you need to significantly change the realm structure that isn't being picked up by the Operator, you may need to **delete the Helm release and reinstall it**.
-* **Caution:** Deleting the release might trigger the deletion of the Keycloak instance and its data (PostgreSQL), depending on your `persistence` and `reclaimPolicy` settings.
+* **Initial import only:** Changes to the import do not reconcile an existing realm.
+* **Existing realms:** Apply required additions through an external Keycloak administration process.
+* **Caution:** Deleting the release to force a new import can delete the Keycloak instance and its data, depending on persistence and reclaim-policy settings.
 
 ---
 

--- a/charts/lifecycle-keycloak/templates/_helpers.tpl
+++ b/charts/lifecycle-keycloak/templates/_helpers.tpl
@@ -107,12 +107,29 @@ Namespace Hostname
 {{- end -}}
 {{- end -}}
 
+{{- define "lifecycle-keycloak.nameWithSuffix" -}}
+{{- $prefix := .prefix -}}
+{{- $suffix := .suffix -}}
+{{- $maxPrefixLength := int (sub 62 (len $suffix)) -}}
+{{- $boundedPrefix := trunc $maxPrefixLength $prefix | trimSuffix "-" -}}
+{{- printf "%s-%s" $boundedPrefix $suffix | trimSuffix "-" -}}
+{{- end -}}
+
 {{- define "lifecycle-keycloak.apiPrincipalSyncSecretName" -}}
 {{- if .Values.secrets.apiPrincipalSync.fullnameOverride -}}
     {{- .Values.secrets.apiPrincipalSync.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
     {{- $prefix := include "lifecycle-keycloak.fullname" . -}}
-    {{- printf "%s-%s" $prefix "api-principal-sync" | trunc 63 | trimSuffix "-" -}}
+    {{- include "lifecycle-keycloak.nameWithSuffix" (dict "prefix" $prefix "suffix" "api-principal-sync") -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "lifecycle-keycloak.apiKeycloakManagementSecretName" -}}
+{{- if .Values.secrets.apiKeycloakManagement.fullnameOverride -}}
+    {{- .Values.secrets.apiKeycloakManagement.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+    {{- $prefix := include "lifecycle-keycloak.fullname" . -}}
+    {{- include "lifecycle-keycloak.nameWithSuffix" (dict "prefix" $prefix "suffix" "api-keycloak-management") -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/lifecycle-keycloak/templates/api-keycloak-management-secret.yaml
+++ b/charts/lifecycle-keycloak/templates/api-keycloak-management-secret.yaml
@@ -15,13 +15,12 @@ limitations under the License.
 */}}
 
 {{- $namespace := .Release.Namespace -}}
-{{- $secretName := printf "%s" (include "lifecycle-keycloak.apiPrincipalSyncSecretName" .) -}}
+{{- $secretName := printf "%s" (include "lifecycle-keycloak.apiKeycloakManagementSecretName" .) -}}
 {{- $apiVersion := "v1" -}}
 {{- $component := "keycloak" -}}
 
-{{- /* Keep the realm-import substitution and worker credential stable across upgrades. */}}
-{{- if and .Values.clients.lifecycleApiPrincipalSync.enabled .Values.secrets.apiPrincipalSync.enabled (not (lookup $apiVersion "Secret" $namespace $secretName)) }}
-{{- with .Values.secrets.apiPrincipalSync -}}
+{{- if and .Values.clients.lifecycleApiKeycloakManagement.enabled .Values.secrets.apiKeycloakManagement.enabled (not (lookup $apiVersion "Secret" $namespace $secretName)) }}
+{{- with .Values.secrets.apiKeycloakManagement -}}
 apiVersion: {{ $apiVersion }}
 kind: Secret
 metadata:

--- a/charts/lifecycle-keycloak/templates/keycloak-instance.yaml
+++ b/charts/lifecycle-keycloak/templates/keycloak-instance.yaml
@@ -106,13 +106,6 @@ spec:
                   secretKeyRef:
                     name: {{ tpl (.Values.clients.lifecycleUi.clientSecret.secretKeyRef.name | default (include "lifecycle-keycloak.lifecycleUiSecretName" .)) . | quote }}
                     key: {{ .Values.clients.lifecycleUi.clientSecret.secretKeyRef.key | default "clientSecret" | quote }}
-              {{- if .Values.clients.lifecycleApiPrincipalSync.enabled }}
-              - name: LIFECYCLE_API_PRINCIPAL_SYNC_CLIENT_SECRET
-                valueFrom:
-                  secretKeyRef:
-                    name: {{ tpl (.Values.clients.lifecycleApiPrincipalSync.clientSecret.secretKeyRef.name | default (include "lifecycle-keycloak.apiPrincipalSyncSecretName" .)) . | quote }}
-                    key: {{ .Values.clients.lifecycleApiPrincipalSync.clientSecret.secretKeyRef.key | default "clientSecret" | quote }}
-              {{- end }}
             volumeMounts:
               - name: vault-volume
                 mountPath: /opt/keycloak/vault
@@ -138,5 +131,9 @@ spec:
                   path: template.ftl
                 - key: login.ftl
                   path: login.ftl
+                - key: login-oauth-grant.ftl
+                  path: login-oauth-grant.ftl
                 - key: link-idp-action.ftl
                   path: link-idp-action.ftl
+                - key: messages_en.properties
+                  path: messages/messages_en.properties

--- a/charts/lifecycle-keycloak/templates/lifecycle-realm-kri.yaml
+++ b/charts/lifecycle-keycloak/templates/lifecycle-realm-kri.yaml
@@ -27,6 +27,21 @@ metadata:
   {{- end }}
 spec:
   keycloakCRName: {{ include "lifecycle-keycloak.fullname" . }}
+{{- if or .Values.clients.lifecycleApiKeycloakManagement.enabled .Values.clients.lifecycleApiPrincipalSync.enabled }}
+  placeholders:
+{{- if .Values.clients.lifecycleApiKeycloakManagement.enabled }}
+    LIFECYCLE_API_KEYCLOAK_MANAGEMENT_CLIENT_SECRET:
+      secret:
+        name: {{ tpl (.Values.clients.lifecycleApiKeycloakManagement.clientSecret.secretKeyRef.name | default (include "lifecycle-keycloak.apiKeycloakManagementSecretName" .)) . | quote }}
+        key: {{ .Values.clients.lifecycleApiKeycloakManagement.clientSecret.secretKeyRef.key | default "clientSecret" | quote }}
+{{- end }}
+{{- if .Values.clients.lifecycleApiPrincipalSync.enabled }}
+    LIFECYCLE_API_PRINCIPAL_SYNC_CLIENT_SECRET:
+      secret:
+        name: {{ tpl (.Values.clients.lifecycleApiPrincipalSync.clientSecret.secretKeyRef.name | default (include "lifecycle-keycloak.apiPrincipalSyncSecretName" .)) . | quote }}
+        key: {{ .Values.clients.lifecycleApiPrincipalSync.clientSecret.secretKeyRef.key | default "clientSecret" | quote }}
+{{- end }}
+{{- end }}
   realm:
     realm: {{ .Values.realm | quote }}
     displayName: {{ .Values.realmDisplayName | quote }}
@@ -185,6 +200,23 @@ spec:
               introspection.token.claim: "true"
       {{- end }}
 
+      {{- if .Values.clients.lifecycleApiKeycloakManagement.enabled }}
+      - clientId: {{ .Values.clients.lifecycleApiKeycloakManagement.clientId | quote }}
+        name: "Lifecycle API Keycloak management"
+        description: "Confidential service-account client the Lifecycle web process uses to manage Lifecycle-owned Keycloak configuration"
+        enabled: true
+        publicClient: false
+        clientAuthenticatorType: "client-secret"
+        secret: "${LIFECYCLE_API_KEYCLOAK_MANAGEMENT_CLIENT_SECRET}"
+        protocol: "openid-connect"
+        serviceAccountsEnabled: true
+        standardFlowEnabled: false
+        implicitFlowEnabled: false
+        directAccessGrantsEnabled: false
+        fullScopeAllowed: false
+        defaultClientScopes: ["roles", "basic"]
+      {{- end }}
+
       {{- if .Values.clients.lifecycleApiPrincipalSync.enabled }}
       - clientId: {{ .Values.clients.lifecycleApiPrincipalSync.clientId | quote }}
         name: "Lifecycle API principal sync"
@@ -202,9 +234,19 @@ spec:
         defaultClientScopes: ["roles", "basic"]
       {{- end }}
 
-    {{- if .Values.clients.lifecycleApiPrincipalSync.enabled }}
+    {{- if or .Values.clients.lifecycleApiKeycloakManagement.enabled .Values.clients.lifecycleApiPrincipalSync.enabled }}
     # --- SERVICE ACCOUNTS ---
     users:
+      {{- if .Values.clients.lifecycleApiKeycloakManagement.enabled }}
+      - username: {{ printf "service-account-%s" .Values.clients.lifecycleApiKeycloakManagement.clientId | quote }}
+        enabled: true
+        serviceAccountClientId: {{ .Values.clients.lifecycleApiKeycloakManagement.clientId | quote }}
+        clientRoles:
+          realm-management:
+            - "manage-clients"
+            - "manage-realm"
+      {{- end }}
+      {{- if .Values.clients.lifecycleApiPrincipalSync.enabled }}
       - username: {{ printf "service-account-%s" .Values.clients.lifecycleApiPrincipalSync.clientId | quote }}
         enabled: true
         serviceAccountClientId: {{ .Values.clients.lifecycleApiPrincipalSync.clientId | quote }}
@@ -212,14 +254,24 @@ spec:
           realm-management:
             - "view-users"
             - "query-users"
+      {{- end }}
 
-    # fullScopeAllowed is off, so this scope mapping is what lets the two roles into the token.
+    # fullScopeAllowed is off, so these mappings put only the assigned
+    # realm-management roles (and Keycloak composites) into each token.
     clientScopeMappings:
       realm-management:
+        {{- if .Values.clients.lifecycleApiKeycloakManagement.enabled }}
+        - client: {{ .Values.clients.lifecycleApiKeycloakManagement.clientId | quote }}
+          roles:
+            - "manage-clients"
+            - "manage-realm"
+        {{- end }}
+        {{- if .Values.clients.lifecycleApiPrincipalSync.enabled }}
         - client: {{ .Values.clients.lifecycleApiPrincipalSync.clientId | quote }}
           roles:
             - "view-users"
             - "query-users"
+        {{- end }}
     {{- end }}
 
     # --- IDENTITY PROVIDERS ---

--- a/charts/lifecycle-keycloak/templates/login-theme-configmap.yaml
+++ b/charts/lifecycle-keycloak/templates/login-theme-configmap.yaml
@@ -127,6 +127,44 @@ data:
                 align-items: center;
             }
             .btn-primary:hover { opacity: 0.9; }
+            .btn-secondary {
+                background: none;
+                color: inherit;
+                font-weight: 500;
+                padding: 0.625rem;
+                border-radius: 0.375rem;
+                border: 1px solid #e4e4e7;
+                cursor: pointer;
+                display: flex;
+                justify-content: center;
+                align-items: center;
+            }
+            .btn-secondary:hover { background-color: #f4f4f5; }
+            .btn-row { display: flex; flex-direction: row-reverse; gap: 0.75rem; margin-top: 0.5rem; }
+            .btn-row > * { flex: 1; }
+            .btn-primary, .btn-secondary { position: relative; transition: transform 0.1s, opacity 0.2s; }
+            .btn-primary:active, .btn-secondary:active { transform: scale(0.97); }
+            .btn-spinner {
+                display: none;
+                position: absolute;
+                width: 1rem;
+                height: 1rem;
+                border: 2px solid currentColor;
+                border-top-color: transparent;
+                border-radius: 9999px;
+                animation: btn-spin 0.6s linear infinite;
+            }
+            .is-loading .btn-label { visibility: hidden; }
+            .is-loading .btn-spinner { display: block; }
+            .is-submitting .btn-row > * { pointer-events: none; }
+            .is-submitting .btn-row > :not(.is-loading) { opacity: 0.5; }
+            @keyframes btn-spin { to { transform: rotate(360deg); } }
+
+            /* Consent */
+            .scope-list { list-style: none; display: flex; flex-direction: column; gap: 0.5rem; text-align: left; margin-bottom: 0.75rem; }
+            .scope-list li { display: flex; align-items: flex-start; gap: 0.625rem; padding: 0.625rem 0.75rem; border: 1px solid #e4e4e7; border-radius: 0.5rem; font-size: 0.875rem; }
+            .scope-check { color: #16a34a; font-weight: 700; }
+            .scope-note { text-align: left; font-size: 0.8125rem; margin-bottom: 0.5rem; }
 
             /* Dark Mode */
             @media (prefers-color-scheme: dark) {
@@ -134,6 +172,9 @@ data:
                 .bg-card { background-color: #09090b; border-color: #27272a; color: #fff; }
                 input { background-color: #09090b; border-color: #27272a; color: #fff; }
                 .btn-primary { background-color: #fafafa; color: #000; }
+                .btn-secondary { border-color: #27272a; }
+                .btn-secondary:hover { background-color: #18181b; }
+                .scope-list li { border-color: #27272a; }
             }
         </style>
     </head>
@@ -160,6 +201,58 @@ data:
     </body>
     </html>
     </#macro>
+
+  login-oauth-grant.ftl: |
+    <#import "template.ftl" as layout>
+    <@layout.registrationLayout; section>
+        <#if section = "header">
+            Grant access
+        <#elseif section = "description">
+            ${advancedMsg(client.name!client.clientId)} wants to:
+        <#elseif section = "form">
+            <ul class="scope-list">
+                <#if oauth.clientScopesRequested??>
+                    <#list oauth.clientScopesRequested as clientScope>
+                        <li><span class="scope-check">&#10003;</span><span>${advancedMsg(clientScope.consentScreenText)}</span></li>
+                    </#list>
+                </#if>
+            </ul>
+            <p class="text-muted scope-note">You can remove this access anytime in your Lifecycle account.</p>
+            <form action="${url.oauthAction}" method="post" class="form-wrapper" id="kc-consent-form">
+                <input type="hidden" name="code" value="${oauth.code}">
+                <div class="btn-row">
+                    <button name="accept" id="kc-login" type="submit" class="btn-primary">
+                        <span class="btn-label">Allow access</span>
+                        <span class="btn-spinner" aria-hidden="true"></span>
+                    </button>
+                    <button name="cancel" id="kc-cancel" type="submit" class="btn-secondary">
+                        <span class="btn-label">Cancel</span>
+                        <span class="btn-spinner" aria-hidden="true"></span>
+                    </button>
+                </div>
+            </form>
+            <script>
+                (function () {
+                    var form = document.getElementById('kc-consent-form');
+                    var submitted = false;
+                    form.addEventListener('submit', function (event) {
+                        if (submitted) {
+                            event.preventDefault();
+                            return;
+                        }
+                        submitted = true;
+                        var button = event.submitter || document.getElementById('kc-login');
+                        button.classList.add('is-loading');
+                        button.setAttribute('aria-busy', 'true');
+                        form.classList.add('is-submitting');
+                    });
+                })();
+            </script>
+        </#if>
+    </@layout.registrationLayout>
+
+  messages_en.properties: |
+    offlineAccessScopeConsentText=Stay signed in until you remove access
 
   link-idp-action.ftl: |
     <#import "template.ftl" as layout>

--- a/charts/lifecycle-keycloak/templates/validate-api-credential-secret-isolation.yaml
+++ b/charts/lifecycle-keycloak/templates/validate-api-credential-secret-isolation.yaml
@@ -1,0 +1,25 @@
+{{- /*
+Copyright 2026 GoodRx, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if and .Values.clients.lifecycleApiKeycloakManagement.enabled .Values.clients.lifecycleApiPrincipalSync.enabled -}}
+{{- $managementSecretName := tpl (.Values.clients.lifecycleApiKeycloakManagement.clientSecret.secretKeyRef.name | default (include "lifecycle-keycloak.apiKeycloakManagementSecretName" .)) . -}}
+{{- $managementSecretKey := .Values.clients.lifecycleApiKeycloakManagement.clientSecret.secretKeyRef.key | default "clientSecret" -}}
+{{- $principalSyncSecretName := tpl (.Values.clients.lifecycleApiPrincipalSync.clientSecret.secretKeyRef.name | default (include "lifecycle-keycloak.apiPrincipalSyncSecretName" .)) . -}}
+{{- $principalSyncSecretKey := .Values.clients.lifecycleApiPrincipalSync.clientSecret.secretKeyRef.key | default "clientSecret" -}}
+{{- if and (eq $managementSecretName $principalSyncSecretName) (eq $managementSecretKey $principalSyncSecretKey) -}}
+{{- fail "Lifecycle API Keycloak-management and principal-sync credentials must reference distinct Kubernetes Secret keys" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/lifecycle-keycloak/values.yaml
+++ b/charts/lifecycle-keycloak/values.yaml
@@ -45,10 +45,24 @@ clients:
     enabled: true
     clientId: lifecycle-cli
 
+  # Confidential service-account client used only by the Lifecycle web process
+  # to manage Lifecycle-owned Keycloak configuration.
+  lifecycleApiKeycloakManagement:
+    # -- Bootstrap the web-only Lifecycle API Keycloak-management credential.
+    enabled: true
+    # -- Keycloak client ID for the web-only management credential.
+    clientId: lifecycle-api-keycloak-management
+    clientSecret:
+      secretKeyRef:
+        name:  # fallback to "{{ include "lifecycle-keycloak.apiKeycloakManagementSecretName" . }}"
+        key:  # default "clientSecret"
+
   # Confidential service-account client the Lifecycle API uses to revoke personal
   # API keys of disabled/deleted owners (realm-management view-users + query-users only).
   lifecycleApiPrincipalSync:
+    # -- Bootstrap the worker-only read-only principal-sync credential.
     enabled: true
+    # -- Keycloak client ID for the worker-only principal-sync credential.
     clientId: lifecycle-api-principal-sync
     clientSecret:
       secretKeyRef:
@@ -149,9 +163,17 @@ secrets:
     clientSecret:
 
   apiPrincipalSync:
+    # -- Create the lookup-stable principal-sync client Secret.
     enabled: true
     fullnameOverride: ""
-    annotations: []
+    annotations: {}
+    clientSecret:
+
+  apiKeycloakManagement:
+    # -- Create the lookup-stable Keycloak-management client Secret.
+    enabled: true
+    fullnameOverride: ""
+    annotations: {}
     clientSecret:
 
 keycloakPostgres:

--- a/scripts/test-keycloak-credential-isolation.sh
+++ b/scripts/test-keycloak-credential-isolation.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 GoodRx, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+scratch_root=$(mktemp -d)
+trap 'rm -rf -- "$scratch_root"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+repeat_a() {
+  local length=$1
+  local value
+  printf -v value '%*s' "$length" ''
+  printf '%s' "${value// /a}"
+}
+
+trim_yaml_scalar() {
+  local value=$1
+  value=${value#\"}
+  value=${value%\"}
+  printf '%s' "$value"
+}
+
+source_metadata_name() {
+  local source=$1
+  awk -v marker="# Source: ${source}" '
+    $0 == marker { in_source = 1; next }
+    in_source && /^---$/ { exit }
+    in_source && /^  name:/ { print $2; exit }
+  '
+}
+
+placeholder_secret_name() {
+  local placeholder=$1
+  awk -v placeholder="${placeholder}:" '
+    index($0, placeholder) { in_placeholder = 1; next }
+    in_placeholder && $1 == "name:" { print $2; exit }
+  '
+}
+
+assert_distinct_suffixes() {
+  local context=$1
+  local management_name=$2
+  local principal_sync_name=$3
+
+  [[ "$management_name" != "$principal_sync_name" ]] ||
+    fail "${context}: credential Secret names collided at ${management_name}"
+  [[ "$management_name" == *-api-keycloak-management ]] ||
+    fail "${context}: management suffix was not preserved: ${management_name}"
+  [[ "$principal_sync_name" == *-api-principal-sync ]] ||
+    fail "${context}: principal-sync suffix was not preserved: ${principal_sync_name}"
+  ((${#management_name} <= 63)) ||
+    fail "${context}: management Secret name exceeds 63 characters"
+  ((${#principal_sync_name} <= 63)) ||
+    fail "${context}: principal-sync Secret name exceeds 63 characters"
+}
+
+standalone_chart="$scratch_root/lifecycle-keycloak"
+mkdir -p "$standalone_chart"
+cp "$repo_root/charts/lifecycle-keycloak/values.yaml" "$standalone_chart/values.yaml"
+cp -R "$repo_root/charts/lifecycle-keycloak/templates" "$standalone_chart/templates"
+
+cat >"$standalone_chart/Chart.yaml" <<'EOF'
+apiVersion: v2
+name: lifecycle-keycloak
+description: Minimal dependency-free chart for credential isolation regression tests
+type: application
+version: 0.0.0-test
+appVersion: 0.0.0-test
+EOF
+
+render_standalone() {
+  local release_name=$1
+  shift
+  helm template "$release_name" "$standalone_chart" \
+    --api-versions k8s.keycloak.org/v2alpha1 \
+    --set-string secrets.githubIdp.clientId=test-client \
+    --set-string secrets.githubIdp.clientSecret=test-secret \
+    "$@"
+}
+
+for release_length in 38 39 53; do
+  release_name=$(repeat_a "$release_length")
+  rendered=$(render_standalone "$release_name")
+
+  management_name=$(trim_yaml_scalar "$(
+    printf '%s\n' "$rendered" |
+      source_metadata_name "lifecycle-keycloak/templates/api-keycloak-management-secret.yaml"
+  )")
+  principal_sync_name=$(trim_yaml_scalar "$(
+    printf '%s\n' "$rendered" |
+      source_metadata_name "lifecycle-keycloak/templates/api-principal-sync-secret.yaml"
+  )")
+  assert_distinct_suffixes \
+    "standalone release length ${release_length}" \
+    "$management_name" \
+    "$principal_sync_name"
+
+  management_placeholder=$(trim_yaml_scalar "$(
+    printf '%s\n' "$rendered" |
+      placeholder_secret_name "LIFECYCLE_API_KEYCLOAK_MANAGEMENT_CLIENT_SECRET"
+  )")
+  principal_sync_placeholder=$(trim_yaml_scalar "$(
+    printf '%s\n' "$rendered" |
+      placeholder_secret_name "LIFECYCLE_API_PRINCIPAL_SYNC_CLIENT_SECRET"
+  )")
+  [[ "$management_placeholder" == "$management_name" ]] ||
+    fail "standalone release length ${release_length}: management placeholder references ${management_placeholder}"
+  [[ "$principal_sync_placeholder" == "$principal_sync_name" ]] ||
+    fail "standalone release length ${release_length}: principal-sync placeholder references ${principal_sync_placeholder}"
+done
+
+if render_standalone collision-check \
+  --set-string clients.lifecycleApiKeycloakManagement.clientSecret.secretKeyRef.name=shared-api-credential \
+  --set-string clients.lifecycleApiPrincipalSync.clientSecret.secretKeyRef.name=shared-api-credential \
+  >/dev/null 2>&1; then
+  fail "standalone chart accepted one Secret identity for both API credentials"
+fi
+
+render_standalone shared-secret-distinct-keys \
+  --set-string clients.lifecycleApiKeycloakManagement.clientSecret.secretKeyRef.name=shared-api-credential \
+  --set-string clients.lifecycleApiKeycloakManagement.clientSecret.secretKeyRef.key=managementSecret \
+  --set-string clients.lifecycleApiPrincipalSync.clientSecret.secretKeyRef.name=shared-api-credential \
+  --set-string clients.lifecycleApiPrincipalSync.clientSecret.secretKeyRef.key=principalSyncSecret \
+  >/dev/null
+
+printf 'Keycloak credential Secret isolation render tests passed.\n'


### PR DESCRIPTION
- Releases lifecycle-keycloak chart 0.7.6.
- Adds a dedicated Keycloak-management service-account client for Lifecycle MCP reconciliation.
- Grants only the required manage-clients and manage-realm roles.
- Generates retained, collision-safe credentials isolated from the principal-sync client.
- Uses realm-import Secret placeholders without exposing API credentials to the Keycloak pod.
- Adds the MCP OAuth consent-screen theme and offline-access messaging.
- Documents existing-realm setup, credential rotation, recovery, and durable disable/re-enable behavior.
- Adds render tests for credential isolation and long Helm release names.